### PR TITLE
Redid abundance model and made storage of broadening schemes much more generic

### DIFF
--- a/Source/CAtmosphere.pyx
+++ b/Source/CAtmosphere.pyx
@@ -8,7 +8,7 @@ from libc.math cimport sqrt, exp, copysign
 from .atmosphere import BoundaryCondition
 from .atomic_model import AtomicLine, LineType
 from .utils import InitialSolution, ExplodingMatrixError, UnityCrswIterator
-from scipy.interpolate import interp1d
+from weno4 import weno4
 import lightweaver.constants as Const
 import time
 from enum import Enum, auto
@@ -75,7 +75,7 @@ cdef extern from "Background.hpp":
         F64View2D chi
         F64View2D eta
         F64View2D scatt
-    
+
     cdef void basic_background(BackgroundData* bg, Atmosphere* atmos)
     cdef f64 Gaunt_bf(f64, f64, int)
 
@@ -155,6 +155,8 @@ cdef extern from "Lightweaver.hpp":
         F64View2D nStar
         F64View vBroad
         F64View nTotal
+        F64View stages
+
         F64View3D Gamma
         F64View3D C
 
@@ -186,7 +188,7 @@ cdef extern from "Lightweaver.hpp":
         int Nthreads
         void initialise_threads()
         void update_threads()
-    
+
     cdef cppclass PrdIterData:
         int iter
         f64 dRho
@@ -432,8 +434,8 @@ cdef class LwAtmosphere:
         self.atmos.mux = f64_view(self.mux)
         self.wmu = state['wmu']
         self.atmos.wmu = f64_view(self.wmu)
-        
-        cdef int Nspace = self.temperature.shape[0] 
+
+        cdef int Nspace = self.temperature.shape[0]
         self.atmos.Nspace = Nspace
         cdef int Nrays = self.vlosMu.shape[0]
         self.atmos.Nrays = Nrays
@@ -542,7 +544,7 @@ cdef class LwAtmosphere:
         else:
             raise ValueError('Unknown bc')
 
-    
+
 cdef class LwBackground:
     cdef Background background
     cdef BackgroundData bd
@@ -577,8 +579,7 @@ cdef class LwBackground:
 
         self.hMinusPops = eqPops['H-']
         self.bd.hMinusPops = f64_view(self.hMinusPops)
-        # NOTE(cmo): Use LTE hydrogen pops here. If NLTE pops are wanted call update_background. Alternatively, add another flag to context construction
-        self.hPops = eqPops.atomicPops['H'].nStar
+        self.hPops = eqPops['H']
         self.bd.hPops = f64_view_2(self.hPops)
 
         self.wavelength = wavelength
@@ -614,11 +615,11 @@ cdef class LwBackground:
 
     cpdef update_background(self, atmos):
         cdef LwAtmosphere lwAtmos = atmos
-        self.hPops = self.eqPops.atomicPops['H'].n
+        self.hPops = self.eqPops['H']
         self.bd.hPops = f64_view_2(self.hPops)
 
         basic_background(&self.bd, &lwAtmos.atmos)
-        self.rayleigh_scattering(lwAtmos, useLte=False)
+        self.rayleigh_scattering(lwAtmos)
         self.bf_opacities(lwAtmos)
 
         cdef int la, k
@@ -703,14 +704,14 @@ cdef class LwBackground:
     def sca(self):
         return np.asarray(self.sca)
 
-    cpdef rayleigh_scattering(self, atmosphere, useLte=True):
+    cpdef rayleigh_scattering(self, atmosphere):
         cdef LwAtmosphere atmos = atmosphere
         cdef f64[::1] sca = np.zeros(atmos.Nspace)
         cdef int k, la
         cdef RayleighScatterer rayH, rayHe
 
         if 'H' in self.radSet:
-            hPops = self.eqPops.atomicPops['H'].nStar if useLte else self.eqPops['H']
+            hPops = self.eqPops['H']
             rayH = RayleighScatterer(atmos, self.radSet['H'], hPops)
             for la in range(self.wavelength.shape[0]):
                 if rayH.scatter(self.wavelength[la], sca):
@@ -718,7 +719,7 @@ cdef class LwBackground:
                         self.sca[la, k] += sca[k]
 
         if 'He' in self.radSet:
-            hePops = self.eqPops.atomicPops['He'].nStar if useLte else self.eqPops['He']
+            hePops = self.eqPops['He']
             rayHe = RayleighScatterer(atmos, self.radSet['He'], hePops)
             for la in range(self.wavelength.shape[0]):
                 if rayHe.scatter(self.wavelength[la], sca):
@@ -727,6 +728,7 @@ cdef class LwBackground:
 
     cpdef bf_opacities(self, atmosphere):
         cdef LwAtmosphere atmos = atmosphere
+        cdef int Nspace = atmos.Nspace
         atoms = self.radSet.passiveAtoms
         # print([a.name for a in atoms])
         if len(atoms) == 0:
@@ -742,19 +744,20 @@ cdef class LwBackground:
         cdef int i, la, k, Z
         cdef f64 nEff, gbf_0, wav, edge, lambdaMin
         for i, c in enumerate(continua):
-            alphaLa = c.compute_alpha(np.asarray(self.wavelength))
+            alphaLa = c.alpha(np.asarray(self.wavelength))
             for la in range(self.wavelength.shape[0]):
                 alpha[la, i] = alphaLa[la]
 
         cdef f64[:, ::1] expla = np.zeros((self.wavelength.shape[0], atmos.Nspace))
+        cdef f64[::1] temperature = atmos.temperature
         cdef f64 hc_k = Const.HC / (Const.KBoltzmann * Const.NM_TO_M)
         cdef f64 twohc = (2.0 * Const.HC) / Const.NM_TO_M**3
         cdef f64 hc_kla
         for la in range(self.wavelength.shape[0]):
             hc_kla = hc_k / self.wavelength[la]
-            for k in range(atmos.Nspace):
-                expla[la, k] = exp(-hc_kla / atmos.temperature[k])
-        
+            for k in range(Nspace):
+                expla[la, k] = exp(-hc_kla / temperature[k])
+
         cdef f64 twohnu3_c2
         cdef f64 gijk
         cdef int ci
@@ -762,14 +765,14 @@ cdef class LwBackground:
         cdef f64[:,::1] nStar
         cdef f64[:,::1] n
         for i, c in enumerate(continua):
-            nStar = self.eqPops.atomicPops[c.atom.name].nStar
-            n = self.eqPops.atomicPops[c.atom.name].n
+            nStar = self.eqPops.atomicPops[c.atom.element].nStar
+            n = self.eqPops.atomicPops[c.atom.element].n
 
             ci = c.i
             cj = c.j
             for la in range(self.wavelength.shape[0]):
                 twohnu3_c2 = twohc / self.wavelength[la]**3
-                for k in range(atmos.Nspace):
+                for k in range(Nspace):
                     gijk = nStar[ci, k] / nStar[cj, k] * expla[la, k]
                     self.chi[la, k] += alpha[la, i] * (1.0 - expla[la, k]) * n[ci, k]
                     self.eta[la, k] += twohnu3_c2 * gijk * alpha[la, i] * n[cj, k]
@@ -782,6 +785,7 @@ cdef class RayleighScatterer:
     cdef f64[:,::1] pops
     cdef object atom
     cdef bool_t lines
+    cdef list lambdaRed
 
     def __init__(self, atmos, atom, pops):
         if len(atom.lines) == 0:
@@ -789,11 +793,13 @@ cdef class RayleighScatterer:
             return
 
         self.lines = True
+        self.lambdaRed = []
         cdef f64 lambdaLimit = 1e6
         cdef f64 lambdaRed
         for l in atom.lines:
+            lambdaRed = l.wavelength()[-1]
+            self.lambdaRed.append(lambdaRed)
             if l.i == 0:
-                lambdaRed = l.wavelength[-1]
                 lambdaLimit = min(lambdaLimit, lambdaRed)
 
         self.lambdaLimit = lambdaLimit
@@ -815,11 +821,12 @@ cdef class RayleighScatterer:
         cdef f64 g0 = self.atom.levels[0].g
         cdef f64 lambdaRed
         cdef f64 f
-        for l in self.atom.lines:
+        cdef int i
+        for i, l in enumerate(self.atom.lines):
             if l.i != 0:
                 continue
-            
-            lambdaRed = l.wavelength[-1]
+
+            lambdaRed = self.lambdaRed[i]
             if wavelength > lambdaRed:
                 lambda2 = 1.0 / ((wavelength / l.lambda0)**2 - 1.0)
                 f = l.Aji * (l.jLevel.g / g0) * (l.lambda0 * Const.NM_TO_M)**2 / self.C
@@ -828,7 +835,7 @@ cdef class RayleighScatterer:
         cdef f64 sigmaRayleigh = self.sigmaE * fomega
 
         cdef int k
-        for k in range(self.atmos.Nspace):
+        for k in range(sca.shape[0]):
             sca[k] = sigmaRayleigh * self.pops[0, k]
 
         return True
@@ -847,15 +854,15 @@ cdef gII_to_numpy(F64Arr3D gII):
 cdef gII_from_numpy(Transition trans, f64[:,:,::1] gII):
     trans.prdStorage.gII = F64Arr3D(f64_view_3(gII))
 
-cpdef approx_trans_comp(t1, t2):
-    return t1.atom.name == t2.atom.name and t1.j == t2.j and t1.i == t2.i
+# cpdef approx_trans_comp(t1, t2):
+#     return t1.atom.name == t2.atom.name and t1.j == t2.j and t1.i == t2.i
 
-cpdef fast_trans_in(t1, l):
-    for t2 in l:
-        if approx_trans_comp(t1, t2):
-            return True
+# cpdef fast_trans_in(t1, l):
+#     for t2 in l:
+#         if approx_trans_comp(t1, t2):
+#             return True
 
-    return False
+#     return False
 
 cdef class LwTransition:
     cdef Transition trans
@@ -877,20 +884,22 @@ cdef class LwTransition:
     cdef f64[::1] Rji
     cdef object transModel
     cdef object atmos
+    cdef object spect
     cdef public object atom
 
     def __init__(self, trans, compAtom, atmos, spect):
         self.transModel = trans
         self.atom = compAtom
         self.atmos = atmos
-        self.wavelength = trans.wavelength
+        self.spect = spect
+        transId = trans.transId
+        self.wavelength = spect.transWavelengths[transId]
         self.trans.wavelength = f64_view(self.wavelength)
         self.trans.i = trans.i
         self.trans.j = trans.j
         self.trans.polarised = False
-
-        cdef int tIdx = spect.transitions.index(trans)
-        self.trans.Nblue = spect.blueIdx[tIdx]
+        self.trans.Nblue = spect.blueIdx[transId]
+        cdef int Nlambda = self.wavelength.shape[0]
 
         if isinstance(trans, AtomicLine):
             self.trans.type = LINE
@@ -903,32 +912,27 @@ cdef class LwTransition:
             self.aDamp = np.zeros(self.atmos.Nspace)
             self.trans.Qelast = f64_view(self.Qelast)
             self.trans.aDamp = f64_view(self.aDamp)
-            self.phi = np.zeros((self.transModel.Nlambda, self.atmos.Nrays, 2, self.atmos.Nspace))
+            self.phi = np.zeros((Nlambda, self.atmos.Nrays, 2, self.atmos.Nspace))
             self.wphi = np.zeros(self.atmos.Nspace)
             self.trans.phi = f64_view_4(self.phi)
             self.trans.wphi = f64_view(self.wphi)
             self.compute_phi()
             if trans.type == LineType.PRD:
-                self.rhoPrd = np.ones((self.transModel.Nlambda, self.atmos.Nspace))
+                self.rhoPrd = np.ones((Nlambda, self.atmos.Nspace))
                 self.trans.rhoPrd = f64_view_2(self.rhoPrd)
         else:
             self.trans.type = CONTINUUM
-            self.alpha = trans.alpha
+            self.alpha = trans.alpha(np.asarray(self.wavelength))
             self.trans.alpha = f64_view(self.alpha)
             self.trans.dopplerWidth = 1.0
             self.trans.lambda0 = trans.lambda0
-        
-        self.active = np.zeros(len(spect.activeSet), np.int8)
-        cdef int i
-        for i, s in enumerate(spect.activeSet):
-            # if trans in s:
-            # TODO(cmo): compute active array in SpectrumConfiguration
-            if fast_trans_in(trans, s):
-                self.active[i] = 1 # sosumi
+
+        self.active = spect.activeWavelengths[transId].astype(np.int8)
         self.trans.active = BoolView(<bool_t*>&self.active[0], self.active.shape[0])
 
-        self.Rij = np.zeros(self.atmos.Nspace)
-        self.Rji = np.zeros(self.atmos.Nspace)
+        atomicState = self.atom.modelPops
+        self.Rij = atomicState.radiativeRates[(self.trans.i, self.trans.j)]
+        self.Rji = atomicState.radiativeRates[(self.trans.j, self.trans.i)]
         self.trans.Rij = f64_view(self.Rij)
         self.trans.Rji = f64_view(self.Rji)
 
@@ -942,14 +946,16 @@ cdef class LwTransition:
         # object, we should instead fetch them from there
         state = {}
         state['atmos'] = self.atmos
+        state['spect'] = self.spect
         state['transModel'] = self.transModel
         state['type'] = self.type
         state['Nblue'] = self.trans.Nblue
-        state['wavelength'] = self.transModel.wavelength
+        transId = self.transModel.transId
+        state['wavelength'] = self.spect.transWavelengths[transId]
         state['active'] = np.asarray(self.active)
-        cdef int selfIdx = self.atom.trans.index(self)
-        state['Rij'] = self.atom.modelPops.Rij[selfIdx]
-        state['Rji'] = self.atom.modelPops.Rji[selfIdx]
+        modelPops = self.atom.modelPops
+        state['Rij'] = modelPops.radiativeRates[(self.trans.i, self.trans.j)]
+        state['Rji'] = modelPops.radiativeRates[(self.trans.j, self.trans.i)]
         state['polarised'] = False
         if self.type == 'Line':
             state['phi'] = np.asarray(self.phi)
@@ -982,13 +988,14 @@ cdef class LwTransition:
             except AttributeError:
                 state['gII'] = None
         else:
-            state['alpha'] = self.transModel.alpha
+            state['alpha'] = np.asarray(self.alpha)
         return state
 
     def __setstate__(self, state):
         self.transModel = state['transModel']
         trans = self.transModel
         self.atmos = state['atmos']
+        self.spect = state['spect']
         self.wavelength = state['wavelength']
         self.trans.wavelength = f64_view(self.wavelength)
         self.trans.i = trans.i
@@ -1025,19 +1032,19 @@ cdef class LwTransition:
                 self.psiQ = state['psiQ']
                 self.psiU = state['psiU']
                 self.psiV = state['psiV']
-                self.trans.phiQ = f64_view_4(self.phiQ) 
-                self.trans.phiU = f64_view_4(self.phiU) 
-                self.trans.phiV = f64_view_4(self.phiV) 
-                self.trans.psiQ = f64_view_4(self.psiQ) 
-                self.trans.psiU = f64_view_4(self.psiU) 
-                self.trans.psiV = f64_view_4(self.psiV) 
+                self.trans.phiQ = f64_view_4(self.phiQ)
+                self.trans.phiU = f64_view_4(self.phiU)
+                self.trans.phiV = f64_view_4(self.phiV)
+                self.trans.psiQ = f64_view_4(self.psiQ)
+                self.trans.psiU = f64_view_4(self.psiU)
+                self.trans.psiV = f64_view_4(self.psiV)
         else:
             self.trans.type = CONTINUUM
-            self.alpha = trans.alpha
+            self.alpha = state['alpha']
             self.trans.alpha = f64_view(self.alpha)
             self.trans.dopplerWidth = 1.0
             self.trans.lambda0 = trans.lambda0
-        
+
         self.active = state['active']
         self.trans.active = BoolView(<bool_t*>&self.active[0], self.active.shape[0])
 
@@ -1055,7 +1062,6 @@ cdef class LwTransition:
             return
 
         cdef int k
-        cdef int selfIdx = self.atom.trans.index(self)
         if self.wavelength.shape == prevState['wavelength'].shape \
            and np.all(self.wavelength == prevState['wavelength']):
             if prevState['rhoPrd'] is not None:
@@ -1080,7 +1086,7 @@ cdef class LwTransition:
                 for k in range(prevState['rhoPrd'].shape[1]):
                     np.asarray(self.rhoPrd)[:, k] = np.interp(self.wavelength, prevState['wavelength'], prevState['rhoPrd'][:, k])
 
-    
+
     cpdef compute_phi(self):
         if self.type == 'Continuum':
             return
@@ -1090,11 +1096,11 @@ cdef class LwTransition:
             np.ndarray[np.double_t, ndim=1] aDamp
 
         cdef LwAtom atom = self.atom
-        aDamp, Qelast = self.transModel.damping(self.atmos, atom.vBroad, atom.hPops.n[0])
+        aDamp, Qelast = self.transModel.damping(self.atmos, atom.eqPops)
 
         cdef Atmosphere* atmos = atom.atom.atmos
         cdef int i
-        for i in range(Qelast.shape[0]):
+        for i in range(self.Qelast.shape[0]):
             self.Qelast[i] = Qelast[i]
             self.aDamp[i] = aDamp[i]
 
@@ -1107,7 +1113,7 @@ cdef class LwTransition:
         if not self.transModel.polarisable:
             return
 
-        cdef int Nlambda = self.transModel.Nlambda
+        cdef int Nlambda = self.wavelength.shape[0]
         cdef int Nrays = self.atmos.Nrays
         cdef int Nspace = self.atmos.Nspace
         try:
@@ -1129,11 +1135,11 @@ cdef class LwTransition:
         self.trans.polarised = True
 
         cdef LwAtom atom = self.atom
-        aDamp, Qelast = self.transModel.damping(self.atmos, atom.vBroad, atom.hPops.n[0])
+        aDamp, Qelast = self.transModel.damping(self.atmos, atom.eqPops)
 
         cdef Atmosphere* atmos = atom.atom.atmos
         cdef int i
-        for i in range(Qelast.shape[0]):
+        for i in range(self.Qelast.shape[0]):
             self.Qelast[i] = Qelast[i]
             self.aDamp[i] = aDamp[i]
 
@@ -1294,11 +1300,10 @@ cdef class LwAtom:
     cdef f64[:,::1] gij
     cdef f64[:,::1] wla
     cdef f64[::1] stages
-    cdef object atomicTable
     cdef public object atomicModel
     cdef public object modelPops
     cdef object atmos
-    cdef object hPops
+    cdef object eqPops
     cdef list trans
     cdef bool_t detailed
 
@@ -1308,10 +1313,9 @@ cdef class LwAtom:
         self.atmos = atmos
         cdef LwAtmosphere a = cAtmos
         self.atom.atmos = &a.atmos
-        self.hPops = eqPops.atomicPops['H']
-        modelPops = eqPops.atomicPops[atom.name]
+        self.eqPops = eqPops
+        modelPops = eqPops.atomicPops[atom.element]
         self.modelPops = modelPops
-        self.atomicTable = modelPops.model.atomicTable
 
         self.vBroad = atom.vBroad(atmos)
         self.atom.vBroad = f64_view(self.vBroad)
@@ -1319,32 +1323,9 @@ cdef class LwAtom:
         self.atom.nTotal = f64_view(self.nTotal)
 
         self.trans = []
-        modelPops.Rij = []
-        modelPops.Rji = []
-        modelPops.lineRij = []
-        modelPops.lineRji = []
-        # print('Atom: %s' % atom.name)
-        for l in atom.lines:
-            # if l in spect.transitions:
-            if fast_trans_in(l, spect.transitions):
-                # print('Found:', l)
-                self.trans.append(LwTransition(l, self, atmos, spect))
-                modelPops.Rij.append(np.asarray(self.trans[-1].Rij))
-                modelPops.Rji.append(np.asarray(self.trans[-1].Rji))
-                modelPops.lineRij.append(np.asarray(self.trans[-1].Rij))
-                modelPops.lineRji.append(np.asarray(self.trans[-1].Rji))
-        
-        modelPops.continuumRij = []
-        modelPops.continuumRji = []
-        for c in atom.continua:
-            # if c in spect.transitions:
-            if fast_trans_in(c, spect.transitions):
-                # print('Found:', c)
-                self.trans.append(LwTransition(c, self, atmos, spect))
-                modelPops.Rij.append(np.asarray(self.trans[-1].Rij))
-                modelPops.Rji.append(np.asarray(self.trans[-1].Rji))
-                modelPops.continuumRij.append(np.asarray(self.trans[-1].Rij))
-                modelPops.continuumRji.append(np.asarray(self.trans[-1].Rji))
+        for t in atom.transitions:
+            if spect.activeTrans[t.transId]:
+                self.trans.append(LwTransition(t, self, atmos, spect))
 
         cdef LwTransition lt
         for lt in self.trans:
@@ -1363,26 +1344,17 @@ cdef class LwAtom:
             self.atom.C = f64_view_3(self.C)
 
         self.stages = np.array([l.stage for l in self.atomicModel.levels], dtype=np.float64)
+        self.atom.stages = f64_view(self.stages)
         self.nStar = modelPops.nStar
         self.atom.nStar = f64_view_2(self.nStar)
 
         doInitSol = True
+        self.n = modelPops.n
+        self.atom.n = f64_view_2(self.n)
+
         if self.detailed:
-            if modelPops.pops is not None:
-                self.n = modelPops.pops
-            else:
-                self.n = self.nStar
             doInitSol = False
             ngOptions = None
-        else:
-            if modelPops.pops is not None:
-                self.n = modelPops.pops
-                doInitSol = False
-            else:
-                self.n = np.copy(self.nStar)
-                modelPops.pops = np.asarray(self.n)
-
-        self.atom.n = f64_view_2(self.n)
 
         if Ntrans > 0:
             self.gij = np.zeros((Ntrans, atmos.Nspace))
@@ -1424,11 +1396,10 @@ cdef class LwAtom:
         # the pytorch people might have been compelled to write
         # torch.save/load... *cough*
         state = {}
-        state['atomicTable'] = self.atomicTable
         state['atomicModel'] = self.atomicModel
         state['modelPops'] = self.modelPops
         state['atmos'] = self.atmos
-        state['hPops'] = self.hPops
+        state['eqPops'] = self.eqPops
         state['trans'] = [t.__getstate__() for t in self.trans]
         state['detailed'] = self.detailed
         state['vBroad'] = np.asarray(self.vBroad)
@@ -1461,10 +1432,9 @@ cdef class LwAtom:
 
     def __setstate__(self, state):
         self.atomicModel = state['atomicModel']
-        self.atomicTable = state['atomicTable']
         self.modelPops = state['modelPops']
         self.atmos = state['atmos']
-        self.hPops = state['hPops']
+        self.eqPops = state['eqPops']
 
         self.detailed = state['detailed']
 
@@ -1504,6 +1474,7 @@ cdef class LwAtom:
 
 
         self.stages = state['stages']
+        self.atom.stages = f64_view(self.stages)
         self.nStar = state['nStar']
         self.atom.nStar = f64_view_2(self.nStar)
         self.n = state['n']
@@ -1538,9 +1509,8 @@ cdef class LwAtom:
     def compute_collisions(self, fillDiagonal=False):
         cdef np.ndarray[np.double_t, ndim=3] C = np.asarray(self.C)
         C.fill(0.0)
-        cdef np.ndarray[np.double_t, ndim=2] nStar = np.asarray(self.nStar)
         for col in self.atomicModel.collisions:
-            col.compute_rates(self.atmos, nStar, C)
+            col.compute_rates(self.atmos, self.eqPops, C)
         C[C < 0.0] = 0.0
 
         if not fillDiagonal:
@@ -1587,10 +1557,10 @@ cdef class LwAtom:
             delta = self.atom.ng.max_change()
             if delta < 3e-2:
                 end = time.time()
-                print('Converged: %s, %d\nTime: %f' % (self.atomicModel.name, it, end-start))
+                print('Converged: %s, %d\nTime: %f' % (self.atomicModel.element.name, it, end-start))
                 break
         else:
-            print('Escape probability didn\'t converge for %s, setting LTE populations' % self.atomicModel.name)
+            print('Escape probability didn\'t converge for %s, setting LTE populations' % self.atomicModel.element.name)
             n = np.asarray(self.n)
             n[:] = np.asarray(self.nStar)
 
@@ -1650,6 +1620,10 @@ cdef class LwAtom:
     @property
     def trans(self):
         return self.trans
+
+    @property
+    def element(self):
+        return self.atomicModel.element
 
 cdef JRest_to_numpy(F64Arr2D JRest):
     if JRest.data() is NULL:
@@ -1747,7 +1721,6 @@ cdef class LwContext:
     cdef LwBackground background
     cdef LwDepthData depthData
     cdef public dict arguments
-    cdef public object atomicTable
     cdef public object eqPops
     cdef list activeAtoms
     cdef list detailedAtoms
@@ -1763,7 +1736,6 @@ cdef class LwContext:
 
         self.atmos = LwAtmosphere(atmos)
         self.spect = LwSpectrum(spect.wavelength, atmos.Nrays, atmos.Nspace)
-        self.atomicTable = eqPops.atomicTable
         self.conserveCharge = conserveCharge
         self.hprd = hprd
 
@@ -1800,11 +1772,10 @@ cdef class LwContext:
         self.ctx.depthData = &self.depthData.depthData
 
         self.setup_threads(Nthreads)
-        
+
     def __getstate__(self):
         state = {}
         state['arguments'] = self.arguments
-        state['atomicTable'] = self.atomicTable
         state['eqPops'] = self.eqPops
         state['activeAtoms'] = [a.__getstate__() for a in self.activeAtoms]
         state['detailedAtoms'] = [a.__getstate__() for a in self.detailedAtoms]
@@ -1820,10 +1791,9 @@ cdef class LwContext:
             state['crswCallback'] = None
         state['depthData'] = self.depthData.__getstate__()
         return state
-        
+
     def __setstate__(self, state):
         self.arguments = state['arguments']
-        self.atomicTable = state['atomicTable']
         self.eqPops = state['eqPops']
         self.atmos = LwAtmosphere.__new__(LwAtmosphere)
         self.atmos.__setstate__(state['atmos'])
@@ -1930,7 +1900,7 @@ cdef class LwContext:
         # print('dJ = %.2e' % dJ)
         return dJ
 
-    cpdef update_deps(self, temperature=True, ne=True, vturb=True, vlos=True, B=True, background=True):
+    cpdef update_deps(self, temperature=True, ne=True, vturb=True, vlos=True, B=True, background=True, hprd=True):
         if vlos or B:
             self.atmos.update_projections()
 
@@ -1942,6 +1912,9 @@ cdef class LwContext:
 
         if background and any([temperature, ne, vturb, vlos]):
             self.background.update_background(self.atmos)
+
+        if self.hprd and hprd:
+            self.update_hprd_coeffs()
 
     cpdef time_dep_update(self, f64 dt, prevTimePops=None):
         atoms = self.activeAtoms
@@ -1966,7 +1939,7 @@ cdef class LwContext:
             accelerated = a.ng.accelerate(a.n.flatten())
             delta = a.ng.max_change()
             maxDelta = max(maxDelta, delta)
-            s = '    %s delta = %6.4e' % (atom.atomicModel.name, delta)
+            s = '    %s delta = %6.4e' % (atom.atomicModel.element.name, delta)
             if accelerated:
                 s += ' (accelerated)'
             print(s)
@@ -1979,13 +1952,14 @@ cdef class LwContext:
         cdef int i
         for i, atom in enumerate(self.activeAtoms):
             np.asarray(atom.n)[:] = prevTimePops[i]
-        
+
         np.asarray(self.spect.I).fill(0.0)
         np.asarray(self.spect.J).fill(0.0)
 
     cpdef time_dep_conserve_charge(self, prevTimePops):
         cdef np.ndarray[np.double_t, ndim=1] deltaNe
         cdef LwAtom atom
+        cdef int i, k
 
         atoms = self.activeAtoms
         for i, atom in enumerate(atoms):
@@ -2024,7 +1998,7 @@ cdef class LwContext:
                 raise ExplodingMatrixError('Singular Matrix')
             accelerated = a.ng.accelerate(a.n.flatten())
             delta = a.ng.max_change()
-            s = '    %s delta = %6.4e' % (atom.atomicModel.name, delta)
+            s = '    %s delta = %6.4e' % (atom.atomicModel.element.name, delta)
             if accelerated:
                 s += ' (accelerated)'
             print(s)
@@ -2073,8 +2047,18 @@ cdef class LwContext:
         print('      PRD dRho = %.2e, (sub-iterations: %d)' % (prdIter.dRho, prdIter.iter))
         return prdIter.dRho, prdIter.iter
 
-    cpdef configure_hprd_coeffs(self):
+    cdef configure_hprd_coeffs(self):
         configure_hprd_coeffs(self.ctx)
+
+    cpdef update_hprd_coeffs(self):
+        self.configure_hprd_coeffs()
+        # NOTE(cmo): configure_hprd_coeffs throws away all of the interpolation
+        # stuff stored on each line, and allocates a new block for it, this
+        # means that the Transitions sitting in the threading factories are now
+        # pointing to stale data, so we regenerate the entire threading
+        # context. This is a bit wasteful, but at 8 threads it takes < 3 ms, vs
+        # 500 ms+ for the coeffs on an average CaII + MgII case.
+        self.update_threads()
 
     @property
     def activeAtoms(self):
@@ -2148,7 +2132,7 @@ cdef class LwContext:
         cdef LwAtom a
         for a in ctx.activeAtoms:
             for s in sd['activeAtoms']:
-                if a.atomicModel.name == s['atomicModel'].name:
+                if a.atomicModel.element == s['atomicModel'].element:
                     levels = a.atomicModel.levels == s['atomicModel'].levels
                     if not levels:
                         break
@@ -2175,7 +2159,7 @@ cdef class LwContext:
     def compute_rays(self, wavelengths=None, mus=None, stokes=False, refinePrd=False):
         state = deepcopy(self.state_dict())
         if wavelengths is not None:
-            spect = state['arguments']['spect'].subset_configuration(wavelengths, expandLineGridsNm=5)
+            spect = state['arguments']['spect'].subset_configuration(wavelengths)
         else:
             spect = None
 
@@ -2231,7 +2215,7 @@ cdef class LwContext:
         cdef LwAtom atom
         cdef LwTransition trans = None
         for a in rayCtx.activeAtoms:
-            if a.atomicModel.name == line.atom.name:
+            if a.atomicModel.element == line.atom.element:
                 for t in a.trans:
                     if t.i == line.i and t.j == line.j:
                         trans = t
@@ -2280,5 +2264,5 @@ cdef class LwContext:
         cdef f64[:,::1] contFn = (np.asarray(chiTot) / mu * np.exp(-np.asarray(tau) / mu) * np.asarray(SLine))
 
         result = {'contFn': np.asarray(contFn), 'SLine': np.asarray(SLine), 'tau': np.asarray(tau), 'chiTot': np.asarray(chiTot), 'chiLine': np.asarray(chiLine), 'chiBg': np.asarray(chiBg), 'etaLine': np.asarray(etaLine)}
- 
+
         return result

--- a/Source/LwAtom.hpp
+++ b/Source/LwAtom.hpp
@@ -14,6 +14,7 @@ struct Atom
     F64View2D nStar;
     F64View vBroad;
     F64View nTotal;
+    F64View stages;
 
     F64View3D Gamma;
     F64View3D C;
@@ -36,13 +37,13 @@ struct Atom
         namespace C = Constants;
         constexpr f64 pi4_h = 4.0 * C::Pi / C::HPlanck;
         constexpr f64 hc_4pi = 0.25 * C::HC / C::Pi;
-        constexpr f64 pi4_hc = 1.0 / hc_4pi; 
+        constexpr f64 pi4_hc = 1.0 / hc_4pi;
         constexpr f64 hc_k = C::HC / (C::KBoltzmann * C::NM_TO_M);
         gij.fill(0.0);
         wla.fill(0.0);
         for (int kr = 0; kr < Ntrans; ++kr)
         {
-            auto& t = *trans[kr]; 
+            auto& t = *trans[kr];
             if (!t.active(laIdx))
                 continue;
 

--- a/Source/LwTransition.hpp
+++ b/Source/LwTransition.hpp
@@ -79,6 +79,7 @@ struct Transition
             }
             // NOTE(cmo): Do the HPRD linear interpolation on rho here
             // As we make Uji, Vij, and Vji explicit, there shouldn't be any need for direct access to gij
+            // TODO(cmo): Why doesn't this just modify gij directly at the top of the function?
             if (hPrdCoeffs)
             {
                 for (int k = 0; k < Vij.shape(0); ++k)

--- a/Utils/Abundances.py
+++ b/Utils/Abundances.py
@@ -1,0 +1,315 @@
+# Parsing abundance data from LaTeX tables found in Asplund et al 2009, from
+# source downloaded from ArXiv 0909.0948
+
+from dataclasses import dataclass, asdict
+from typing import List, Iterable
+import pickle
+from itertools import chain
+flatten_list = chain.from_iterable
+
+def expected_mass_from_str(s: str):
+    # NOTE(cmo): Handle [x,y] range by returning mean
+    if s.startswith('[') and ',' in s:
+        vals = tuple(map(float, s[1:-1].split(',')))
+        return 0.5 * (vals[0] + vals[1])
+
+    # NOTE(cmo): Handle [x] by returning x
+    if s.startswith('['):
+        return float(s[1:-1])
+
+    # NOTE(cmo): Handle x.....(y) by returning x
+    if (idx := s.find('(')) != -1:
+        return float(s[:idx])
+
+    # NOTE(cmo): if it's none of these then try to convert to float
+    return float(s)
+
+def parse_nist_mass_blocks(linesIn):
+    lines = linesIn
+    lines = [l.replace('\n', '') for l in lines]
+
+    Z = 0
+    massData = {}
+    nameMapping = {}
+    while len(lines) > 7:
+        while (line := lines[0]) == '' or line.startswith('#'):
+            lines = lines[1:]
+
+        Z = int(lines[0].split('=')[1])
+        if Z > 92:
+            break
+        name = lines[1].split('=')[1].strip()
+        # NOTE(cmo): Ignore the special case names for Deuterium and Tritium for now
+        name = 'H' if (name == 'D' or name == 'T') else name
+        N = int(lines[2].split('=')[1])
+        isoMass = expected_mass_from_str(lines[3].split('=')[1].strip())
+        aMass = expected_mass_from_str(lines[5].split('=')[1].strip())
+
+        lines = lines[7:]
+
+        if Z not in massData:
+            massData[Z] = aMass
+            nameMapping[Z] = name
+            nameMapping[name] = Z
+
+        massData[(N, Z)] = isoMass
+        nameMapping[(N, Z)] = name
+    return massData, nameMapping
+
+# NOTE(cmo): Parse all the masses from the NIST data
+# File isn't a great format.
+with open('NistMasses.txt', 'r') as f:
+    lines = f.readlines()
+
+massData, nameMapping = parse_nist_mass_blocks(lines)
+with open('AtomicMassesNames.pickle', 'wb') as pkl:
+    pickle.dump((massData, nameMapping), pkl)
+
+@dataclass
+class Element:
+    Z: int
+    name: str
+    mass: float
+
+    def __lt__(self, other):
+        return self.Z < other.Z
+
+@dataclass
+class ElementalAbundance:
+    elem: Element
+    abundance: float
+    solarData: bool
+
+    @property
+    def Z(self):
+        return self.elem.Z
+
+    @property
+    def name(self):
+        return self.elem.name
+
+    def __lt__(self, other):
+        return self.Z < other.Z
+
+@dataclass
+class IsotopeProportion:
+    N: int
+    mass: float
+    proportion: float
+
+@dataclass
+class ElementalDistribution:
+    elem: ElementalAbundance
+    isotopes: List[IsotopeProportion]
+
+    @property
+    def Z(self):
+        return self.elem.Z
+
+    @property
+    def name(self):
+        return self.elem.name
+
+    def __lt__(self, other):
+        return self.Z < other.Z
+
+abundanceStr = """\
+1  & H   & $12.00$            &  $8.22 \pm 0.04$        & 44 & Ru  &  $1.75 \pm 0.08$   &  $1.76 \pm 0.03$  \\
+2  & He  & $[10.93 \pm 0.01]$ &  $1.29$                 & 45 & Rh  &  $0.91 \pm 0.10$   &  $1.06 \pm 0.04$  \\
+3  & Li  &  $1.05 \pm 0.10$   &  $3.26 \pm 0.05$        & 46 & Pd  &  $1.57 \pm 0.10$   &  $1.65 \pm 0.02$  \\
+4  & Be  &  $1.38 \pm 0.09$   &  $1.30 \pm 0.03$        & 47 & Ag  &  $0.94 \pm 0.10$   &  $1.20 \pm 0.02$  \\
+5  & B   &  $2.70 \pm 0.20$   &  $2.79 \pm 0.04$        & 48 & Cd  &                    &  $1.71 \pm 0.03$  \\
+6  & C   &  $8.43 \pm 0.05$   &  $7.39 \pm 0.04$        & 49 & In  &  $0.80 \pm 0.20$   &  $0.76 \pm 0.03$  \\
+7  & N   &  $7.83 \pm 0.05$   &  $6.26 \pm 0.06$        & 50 & Sn  &  $2.04 \pm 0.10$   &  $2.07 \pm 0.06$  \\
+8  & O   &  $8.69 \pm 0.05$   &  $8.40 \pm 0.04$        & 51 & Sb  &  $$                &  $1.01 \pm 0.06$  \\
+9  & F   &  $4.56 \pm 0.30$   &  $4.42 \pm 0.06$        & 52 & Te  &                    &  $2.18 \pm 0.03$  \\
+10 & Ne  &  $[7.93 \pm 0.10]$ &  $-1.12$                & 53 & I   &                    &  $1.55 \pm 0.08$  \\
+11 & Na  &  $6.24 \pm 0.04$   &  $6.27 \pm 0.02$        & 54 & Xe  &  $[2.24 \pm 0.06]$ &  $-1.95$  \\
+12 & Mg  &  $7.60 \pm 0.04$   &  $7.53 \pm 0.01$        & 55 & Cs  &                    &  $1.08 \pm 0.02$  \\
+13 & Al  &  $6.45 \pm 0.03$   &  $6.43 \pm 0.01$        & 56 & Ba  &  $2.18 \pm 0.09$   &  $2.18 \pm 0.03$  \\
+14 & Si  &  $7.51 \pm 0.03$   &  $7.51 \pm 0.01$        & 57 & La  &  $1.10 \pm 0.04$   &  $1.17 \pm 0.02$  \\
+15 & P   &  $5.41 \pm 0.03$   &  $5.43 \pm 0.04$        & 58 & Ce  &  $1.58 \pm 0.04$   &  $1.58 \pm 0.02$  \\
+16 & S   &  $7.12 \pm 0.03$   &  $7.15 \pm 0.02$        & 59 & Pr  &  $0.72 \pm 0.04$   &  $0.76 \pm 0.03$  \\
+17 & Cl  &  $5.50 \pm 0.30$   &  $5.23 \pm 0.06$        & 60 & Nd  &  $1.42 \pm 0.04$   &  $1.45 \pm 0.02$  \\
+18 & Ar  &  $[6.40 \pm 0.13]$   &  $-0.50$              & 62 & Sm  &  $0.96 \pm 0.04$   &  $0.94 \pm 0.02$  \\
+19 & K   &  $5.03 \pm 0.09$   &  $5.08 \pm 0.02$        & 63 & Eu  &  $0.52 \pm 0.04$   &  $0.51 \pm 0.02$  \\
+20 & Ca  &  $6.34 \pm 0.04$   &  $6.29 \pm 0.02$        & 64 & Gd  &  $1.07 \pm 0.04$   &  $1.05 \pm 0.02$  \\
+21 & Sc  &  $3.15 \pm 0.04$   &  $3.05 \pm 0.02$        & 65 & Tb  &  $0.30 \pm 0.10$   &  $0.32 \pm 0.03$  \\
+22 & Ti  &  $4.95 \pm 0.05$   &  $4.91 \pm 0.03$        & 66 & Dy  &  $1.10 \pm 0.04$   &  $1.13 \pm 0.02$  \\
+23 & V   &  $3.93 \pm 0.08$   &  $3.96 \pm 0.02$        & 67 & Ho  &  $0.48 \pm 0.11$   &  $0.47 \pm 0.03$  \\
+24 & Cr  &  $5.64 \pm 0.04$   &  $5.64 \pm 0.01$        & 68 & Er  &  $0.92 \pm 0.05$   &  $0.92 \pm 0.02$  \\
+25 & Mn  &  $5.43 \pm 0.05$   &  $5.48 \pm 0.01$        & 69 & Tm  &  $0.10 \pm 0.04$   &  $0.12 \pm 0.03$  \\
+26 & Fe  &  $7.50 \pm 0.04$   &  $7.45 \pm 0.01$        & 70 & Yb  &  $0.84 \pm 0.11$   &  $0.92 \pm 0.02$  \\
+27 & Co  &  $4.99 \pm 0.07$   &  $4.87 \pm 0.01$        & 71 & Lu  &  $0.10 \pm 0.09$   &  $0.09 \pm 0.02$  \\
+28 & Ni  &  $6.22 \pm 0.04$   &  $6.20 \pm 0.01$        & 72 & Hf  &  $0.85 \pm 0.04$   &  $0.71 \pm 0.02$  \\
+29 & Cu  &  $4.19 \pm 0.04$   &  $4.25 \pm 0.04$        & 73 & Ta  &                    &  -$0.12 \pm 0.04$ \\
+30 & Zn  &  $4.56 \pm 0.05$   &  $4.63 \pm 0.04$        & 74 & W   &  $0.85 \pm 0.12$   &  $0.65 \pm 0.04$  \\
+31 & Ga  &  $3.04 \pm 0.09$   &  $3.08 \pm 0.02$        & 75 & Re  &                    &  $0.26 \pm 0.04$  \\
+32 & Ge  &  $3.65 \pm 0.10$   &  $3.58 \pm 0.04$        & 76 & Os  &  $1.40 \pm 0.08$   &  $1.35 \pm 0.03$  \\
+33 & As  &                    &  $2.30 \pm 0.04$        & 77 & Ir  &  $1.38 \pm 0.07$   &  $1.32 \pm 0.02$  \\
+34 & Se  &                    &  $3.34 \pm 0.03$        & 78 & Pt  &                    &  $1.62 \pm 0.03$  \\
+35 & Br  &                    &  $2.54 \pm 0.06$        & 79 & Au  &  $0.92 \pm 0.10$   &  $0.80 \pm 0.04$  \\
+36 & Kr  &  $[3.25 \pm 0.06]$   &  $-2.27$              & 80 & Hg  &                    &  $1.17 \pm 0.08$  \\
+37 & Rb  &  $2.52 \pm 0.10$   &  $2.36 \pm 0.03$        & 81 & Tl  &  $0.90 \pm 0.20$   &  $0.77 \pm 0.03$  \\
+38 & Sr  &  $2.87 \pm 0.07$   &  $2.88 \pm 0.03$        & 82 & Pb  &  $1.75 \pm 0.10$   &  $2.04 \pm 0.03$  \\
+39 & Y   &  $2.21 \pm 0.05$   &  $2.17 \pm 0.04$        & 83 & Bi  &  $$                &  $0.65 \pm 0.04$  \\
+40 & Zr  &  $2.58 \pm 0.04$   &  $2.53 \pm 0.04$        & 90 & Th  &  $0.02 \pm 0.10$   &  $0.06 \pm 0.03$  \\
+41 & Nb  &  $1.46 \pm 0.04$   &  $1.41 \pm 0.04$        & 92 & U   &                    &  -$0.54 \pm 0.03$  \\
+42 & Mo  &  $1.88 \pm 0.08$   &  $1.94 \pm 0.04$        & $$\\
+"""
+
+# NOTE(cmo): Parse the abundance table into a spreadsheet of cells
+replaceChars = ['$', '[', ']', '\\']
+for char in replaceChars:
+    abundanceStr = abundanceStr.replace(char, '')
+
+abundanceRows : List[str] = abundanceStr.split('\n')
+
+splitStrs = ['&']
+abundanceCells = []
+# NOTE(cmo): Also trim off last empty line here with choice of iterable for loop
+for r in abundanceRows[:-1]:
+    row : Iterable[str] = [r]
+    for s in splitStrs:
+        row = flatten_list([x.split(s) for x in row])
+    row = [x.split('pm')[0].strip() if 'pm' in x else x.strip() for x in row]
+    abundanceCells.append(row)
+
+FullRow = len(abundanceCells[0])
+elements = []
+for row in abundanceCells:
+    abund, solar = (float(row[2]), True) if row[2] != '' else (float(row[3]), False)
+    Z = int(row[0])
+    e = ElementalAbundance(elem=Element(Z=Z, name=row[1], mass=massData[Z]),
+                           abundance=abund, solarData=solar)
+    elements.append(e)
+
+    if len(row) < FullRow:
+        continue
+
+    abund, solar = (float(row[-2]), True) if row[-2] != '' else (float(row[-1]), False)
+    Z = int(row[4])
+    e = ElementalAbundance(elem=Element(Z=Z, name=row[5], mass=massData[Z]),
+                           abundance=abund, solarData=solar)
+    elements.append(e)
+
+elements = sorted(elements)
+
+isotopeStr = """\
+H  & 1   & $99.998$  & S  & 32 & $94.93$   & Fe & 57 & $2.119$   & Kr & 82  & $11.655$ & Pd & 105 & $22.33$\\
+   & 2   & $ 0.002$  &    & 33 & $0.76$    &    & 58 & $0.282$   &    & 83  & $11.546$ &    & 106 & $27.33$\\
+   &     &           &    & 34 & $4.29$    &    &    &           &    & 84  & $56.903$ &    & 108 & $26.46$\\
+He & 3   & $0.0166$  &    & 36 & $0.02$    & Co & 59 & $100.0$   &    & 86  & $17.208$ &    & 110 & $11.72$\\
+   & 4   & $99.9834$ &    &    &           &    &    &           &    &     &          &    &     &        \\
+   &     &           & Cl & 35 & $75.78$   & Ni & 58 & $68.0769$ & Rb & 85  & $70.844$ & Ag & 107 & $51.839$\\
+Li & 6   & $7.59$    &    & 37 & $24.22$   &    & 60 & $26.2231$ &    & 87  & $29.156$ &    & 109 & $48.161$\\
+   & 7   & $92.41$   &    &    &           &    & 61 & $1.1399$  &    &     &          &    &     &        \\
+   &     &           & Ar & 36 & $84.5946$ &    & 62 & $3.6345$  & Sr & 84  & $0.5580$ & Cd & 106 & $1.25$\\
+Be & 9   & $100.0$   &    & 38 & $15.3808$ &    & 64 & $0.9256$  &    & 86  & $9.8678$ &    & 108 & $0.89$\\
+   &     &           &    & 40 & $0.0246$  &    &    &           &    & 87  & $6.8961$ &    & 110 & $12.49$\\
+B  & 10  & $19.9$    &    &    &           & Cu & 63 & $69.17$   &    & 88  & $82.6781$&    & 111 & $12.80$\\
+   & 11  & $80.1$    & K  & 39 & $93.132$  &    & 65 & $30.83$   &    &     &          &    & 112 & $24.13$\\
+   &     &           &    & 40 & $0.147$   &    &    &           & Y  & 89  & $100.0$  &    & 113 & $12.22$\\
+C  & 12  & $98.8938$ &    & 41 & $6.721$   & Zn & 64 & $48.63$   &    &     &          &    & 114 & $28.73$\\
+   & 13  & $1.1062$  &    &    &           &    & 66 & $27.90$   & Zr & 90  & $51.45$  &    & 116 & $7.49$\\
+   &     &           & Ca & 40 & $96.941$  &    & 67 & $4.10$    &    & 91  & $11.22$  &    &     &        \\
+N  & 14  & $99.771$  &    & 42 & $0.647$   &    & 68 & $18.75$   &    & 92  & $17.15$  & In & 113 & $4.29$\\
+   & 15  & $0.229$   &    & 43 & $0.135$   &    & 70 & $0.62$    &    & 94  & $17.38$  &    & 115 & $95.71$\\
+   &     &           &    & 44 & $2.086$   &    &    &           &    & 96  & $2.80$   &    &     &        \\
+O  & 16  & $99.7621$ &    & 46 & $0.004$   & Ga & 69 & $60.108$  &    &     &          & Sn & 112 & $0.97$\\
+   & 17  & $0.0379$  &    & 48 & $0.187$   &    & 71 & $39.892$  & Nb & 93  & $100.0$  &    & 114 & $0.66$\\
+   & 18  & $0.2000$  &    &    &           &    &    &           &    &     &          &    & 115 & $0.34$\\
+   &     &           & Sc & 45 & $100.0$   & Ge & 70 & $20.84$   & Mo & 92  & $14.525$ &    & 116 & $14.54$\\
+F  & 19  & $100.0$   &    &    &           &    & 72 & $27.54$   &    & 94  & $9.151$  &    & 117 & $7.68$\\
+   &     &           & Ti & 46 & $8.25$    &    & 73 & $7.73$    &    & 95  & $15.838$ &    & 118 & $24.22$\\
+Ne & 20  & $92.9431$ &    & 47 & $7.44$    &    & 74 & $36.28$   &    & 96  & $16.672$ &    & 119 & $8.59$\\
+   & 21  & $0.2228$  &    & 48 & $73.72$   &    & 76 & $7.61$    &    & 97  & $9.599$  &    & 120 & $32.58$\\
+   & 22  & $6.8341$  &    & 49 & $5.41$    &    &    &           &    & 98  & $24.391$ &    & 122 & $4.63$\\
+   &     &           &    & 50 & $5.18$    & As & 75 & $100.0$   &    & 100 & $9.824$   &    & 124 & $5.79$\\
+Na & 23  & $100.0$   &    &    &           &    &    &           &    &     &          &    &     &        \\
+   &     &           & V  & 50 & $0.250$   & Se & 74 & $0.89$    & Ru & 96  & $5.54$   & Sb & 121 & $57.21$\\
+Mg & 24  & $78.99$   &    & 51 & $99.750$  &    & 76 & $9.37$    &    & 98  & $1.87$   &    & 123 & $42.79$\\
+   & 25  & $10.00$   &    &    &           &    & 77 & $7.63$    &    & 99  & $12.76$  &    &     &        \\
+   & 26  & $11.01$   & Cr & 50 & $4.345$   &    & 78 & $23.77$   &    & 100 & $12.60$  & Te & 120 & $0.09$\\
+   &     &           &    & 52 & $83.789$  &    & 80 & $49.61$   &    & 101 & $17.06$  &    & 122 & $2.55$\\
+Al & 27  & $100.0$   &    & 53 & $9.501$   &    & 82 & $8.73$    &    & 102 & $31.55$  &    & 123 & $0.89$\\
+   &     &           &    & 54 & $2.365$   &    &    &           &    & 104 & $18.62$  &    & 124 & $4.74$\\
+Si & 28  & $92.2297$ &    &    &           & Br & 79 & $50.69$   &    &     &          &    & 125 & $7.07$\\
+   & 29  & $4.6832$  & Mn & 55 & $100.0$   &    & 81 & $49.31$   & Rh & 103 & $100.0$  &    & 126 & $18.84$\\
+   & 30  & $3.0872$  &    &   &            &    &    &           &    &     &          &    & 128 & $31.74$\\
+   &     &           & Fe & 54 & $5.845$   & Kr & 78 & $0.362$   & Pd & 102 & $1.02$   &    & 130 & $34.08$\\
+P  & 31  & $100.0$   &    & 56 & $91.754$  &    & 80 & $2.326$   &    & 104 & $11.14$  &    &     &        \\
+I  & 127 & $100.0$  & Nd & 142 & $27.044$& Dy & 160 & $2.329$   & Hf & 178 & $27.297$ & Pt & 196 & $25.242$ \\
+   &     &          &    & 143 & $12.023$&    & 161 & $18.889$  &    & 179 & $13.629$ &    & 198 & $7.163$  \\
+Xe & 124 & $0.122$  &    & 144 & $23.729$&    & 162 & $25.475$  &    & 180 & $35.100$ &    &     &          \\
+   & 126 & $0.108$  &    & 145 & $8.763$ &    & 163 & $24.896$  &    &     &          & Au & 197 & $100.0$  \\
+   & 128 & $2.188$  &    & 146 & $17.130$&    & 164 & $28.260$  & Ta & 180 & $0.012$  &    &     &          \\
+   & 129 & $27.255$ &    & 148 & $5.716$ &    &     &           &    & 181 & $99.988$ & Hg & 196 & $0.15$   \\
+   & 130 & $4.376$  &    & 150 & $5.596$ & Ho & 165 & $100.0$   &    &     &          &    & 198 & $9.97$   \\
+   & 131 & $21.693$ &    &     &         &    &     &           & W  & 180 & $0.12$   &    & 199 & $16.87$  \\
+   & 132 & $26.514$ & Sm & 144 & $3.07$  & Er & 162 & $0.139$   &    & 182 & $26.50$  &    & 200 & $23.10$  \\
+   & 134 & $9.790$  &    & 147 & $14.99$ &    & 164 & $1.601$   &    & 183 & $14.31$  &    & 201 & $13.18$  \\
+   & 136 & $7.954$  &    & 148 & $11.24$ &    & 166 & $33.503$  &    & 184 & $30.64$  &    & 202 & $29.86$  \\
+   &     &          &    & 149 & $13.82$ &    & 167 & $22.869$  &    & 186 & $28.43$  &    & 204 & $6.87$   \\
+Cs & 133 & $100.0$  &    & 150 & $7.38$  &    & 168 & $26.978$  &    &     &          &    &     &          \\
+   &     &          &    & 152 & $26.75$ &    & 170 & $14.910$  & Re & 185 & $35.662$ & Tl & 203 & $29.524$ \\
+Ba & 130 & $0.106$  &    & 154 & $22.75$ &    &     &           &    & 187 & $64.338$ &    & 205 & $70.476$ \\
+   & 132 & $0.101$  &    &     &         & Tm & 169 & $100.0$   &    &     &          &    &     &          \\
+   & 134 & $2.417$  & Eu & 151 & $47.81$ &    &     &           & Os & 184 & $0.020$  & Pb & 204 & $1.997$  \\
+   & 135 & $6.592$  &    & 153 & $52.19$ & Yb & 168 & $0.12$    &    & 186 & $1.598$  &    & 206 & $18.582$ \\
+   & 136 & $7.854$  &    &     &         &    & 170 & $2.98$    &    & 187 & $1.271$  &    & 207 & $20.563$ \\
+   & 137 & $11.232$ & Gd & 152 & $0.20$  &    & 171 & $14.09$   &    & 188 & $13.337$ &    & 208 & $58.858$ \\
+   & 138 & $71.698$ &    & 154 & $2.18$  &    & 172 & $21.69$   &    & 189 & $16.261$ &    &     &          \\
+   &     &          &    & 155 & $14.80$ &    & 173 & $16.10$   &    & 190 & $26.444$ & Bi & 209 & $100.0$  \\
+La & 138 & $0.091$  &    & 156 & $20.47$ &    & 174 & $32.03$   &    & 192 & $41.070$ &    &     &          \\
+   & 139 & $99.909$ &    & 157 & $15.65$ &    & 176 & $13.00$   &    &     &          & Th & 232 & $100.0$  \\
+   &     &          &    & 158 & $24.84$ &    &     &           & Ir & 191 & $37.3$   &    &     &          \\
+Ce & 136 & $0.185$  &    & 160 & $21.86$ & Lu & 175 & $97.1795$ &    & 193 & $62.7$   & U  & 234 & $0.002$  \\
+   & 138 & $0.251$  &    &     &         &    & 176 & $2.8205$  &    &     &          &    & 235 & $24.286$ \\
+   & 140 & $88.450$ & Tb & 159 & $100.0$ &    &     &           & Pt & 190 & $0.014$  &    & 238 & $75.712$ \\
+   & 142 & $11.114$ &    &     &         & Hf & 174 & $0.162$   &    & 192 & $0.782$  &    &     &          \\
+   &     &          & Dy & 156 & $0.056$ &    & 176 & $5.206$   &    & 194 & $32.967$ &    &     &          \\
+Pr & 141 & $100.0$  &    & 158 & $0.095$ &    & 177 & $18.606$  &    & 195  & $33.832$ &       &      &    \\
+"""
+
+for char in replaceChars:
+    isotopeStr = isotopeStr.replace(char, '')
+
+isotopeRows = isotopeStr.split('\n')
+isotopeCells = [[y.strip() for y in x.split('&')] for x in isotopeRows[:-1]]
+# NOTE(cmo): Each element takes up 3 columns of the row it's in, and is spread
+# over multiple rows, so rearrange into table with 3 columns keeping the
+# elements contiguous in rows.
+isotopeReshape = []
+
+for elemStart in range(0, len(isotopeCells[0]), 3):
+    elemRange = slice(elemStart, elemStart+3)
+    for row in isotopeCells:
+        selection = row[elemRange]
+        if not all([s == '' for s in selection]):
+            isotopeReshape.append(row[elemRange])
+
+dist = []
+for row in isotopeReshape:
+    if row[0] != '':
+        try:
+            elem = [e for e in elements if e.name == row[0]][0]
+        except:
+            raise ValueError('Unable to find element for name %s' % row[0])
+        dist.append(ElementalDistribution(elem, []))
+    N = int(row[1])
+    iso = IsotopeProportion(N=N, proportion=(float(row[2]) / 100),
+                            mass=massData[(N, elem.Z)])
+    dist[-1].isotopes.append(iso)
+
+# NOTE(cmo): Ensure normalisation to machine precision
+for ele in dist:
+    totalAbund = 0.0
+    for iso in ele.isotopes:
+        totalAbund += iso.proportion
+    for iso in ele.isotopes:
+        iso.proportion /= totalAbund
+
+distDict = [asdict(d) for d in dist]
+with open('AbundancesAsplund09.pickle', 'wb') as pkl:
+    pickle.dump(distDict, pkl)

--- a/Utils/NistMasses.txt
+++ b/Utils/NistMasses.txt
@@ -1,0 +1,2833 @@
+# Atomic/isotopic masses from https://www.nist.gov/pml/atomic-weights-and-isotopic-compositions-relative-atomic-masses
+
+Atomic Number = 1
+Atomic Symbol = H
+Mass Number = 1
+Relative Atomic Mass = 1.00782503223(9)
+Isotopic Composition = 0.999885(70)
+Standard Atomic Weight = [1.00784,1.00811]
+Notes = m
+
+Atomic Number = 1
+Atomic Symbol = D
+Mass Number = 2
+Relative Atomic Mass = 2.01410177812(12)
+Isotopic Composition = 0.000115(70)
+Standard Atomic Weight = [1.00784,1.00811]
+Notes = m
+
+Atomic Number = 1
+Atomic Symbol = T
+Mass Number = 3
+Relative Atomic Mass = 3.0160492779(24)
+Isotopic Composition =
+Standard Atomic Weight = [1.00784,1.00811]
+Notes = m
+
+Atomic Number = 2
+Atomic Symbol = He
+Mass Number = 3
+Relative Atomic Mass = 3.0160293201(25)
+Isotopic Composition = 0.00000134(3)
+Standard Atomic Weight = 4.002602(2)
+Notes = g,r
+
+Atomic Number = 2
+Atomic Symbol = He
+Mass Number = 4
+Relative Atomic Mass = 4.00260325413(6)
+Isotopic Composition = 0.99999866(3)
+Standard Atomic Weight = 4.002602(2)
+Notes = g,r
+
+Atomic Number = 3
+Atomic Symbol = Li
+Mass Number = 6
+Relative Atomic Mass = 6.0151228874(16)
+Isotopic Composition = 0.0759(4)
+Standard Atomic Weight = [6.938,6.997]
+Notes = m
+
+Atomic Number = 3
+Atomic Symbol = Li
+Mass Number = 7
+Relative Atomic Mass = 7.0160034366(45)
+Isotopic Composition = 0.9241(4)
+Standard Atomic Weight = [6.938,6.997]
+Notes = m
+
+Atomic Number = 4
+Atomic Symbol = Be
+Mass Number = 9
+Relative Atomic Mass = 9.012183065(82)
+Isotopic Composition = 1
+Standard Atomic Weight = 9.0121831(5)
+Notes =
+
+Atomic Number = 5
+Atomic Symbol = B
+Mass Number = 10
+Relative Atomic Mass = 10.01293695(41)
+Isotopic Composition = 0.199(7)
+Standard Atomic Weight = [10.806,10.821]
+Notes = m
+
+Atomic Number = 5
+Atomic Symbol = B
+Mass Number = 11
+Relative Atomic Mass = 11.00930536(45)
+Isotopic Composition = 0.801(7)
+Standard Atomic Weight = [10.806,10.821]
+Notes = m
+
+Atomic Number = 6
+Atomic Symbol = C
+Mass Number = 12
+Relative Atomic Mass = 12.0000000(00)
+Isotopic Composition = 0.9893(8)
+Standard Atomic Weight = [12.0096,12.0116]
+Notes =
+
+Atomic Number = 6
+Atomic Symbol = C
+Mass Number = 13
+Relative Atomic Mass = 13.00335483507(23)
+Isotopic Composition = 0.0107(8)
+Standard Atomic Weight = [12.0096,12.0116]
+Notes =
+
+Atomic Number = 6
+Atomic Symbol = C
+Mass Number = 14
+Relative Atomic Mass = 14.0032419884(40)
+Isotopic Composition =
+Standard Atomic Weight = [12.0096,12.0116]
+Notes =
+
+Atomic Number = 7
+Atomic Symbol = N
+Mass Number = 14
+Relative Atomic Mass = 14.00307400443(20)
+Isotopic Composition = 0.99636(20)
+Standard Atomic Weight = [14.00643,14.00728]
+Notes =
+
+Atomic Number = 7
+Atomic Symbol = N
+Mass Number = 15
+Relative Atomic Mass = 15.00010889888(64)
+Isotopic Composition = 0.00364(20)
+Standard Atomic Weight = [14.00643,14.00728]
+Notes =
+
+Atomic Number = 8
+Atomic Symbol = O
+Mass Number = 16
+Relative Atomic Mass = 15.99491461957(17)
+Isotopic Composition = 0.99757(16)
+Standard Atomic Weight = [15.99903,15.99977]
+Notes =
+
+Atomic Number = 8
+Atomic Symbol = O
+Mass Number = 17
+Relative Atomic Mass = 16.99913175650(69)
+Isotopic Composition = 0.00038(1)
+Standard Atomic Weight = [15.99903,15.99977]
+Notes =
+
+Atomic Number = 8
+Atomic Symbol = O
+Mass Number = 18
+Relative Atomic Mass = 17.99915961286(76)
+Isotopic Composition = 0.00205(14)
+Standard Atomic Weight = [15.99903,15.99977]
+Notes =
+
+Atomic Number = 9
+Atomic Symbol = F
+Mass Number = 19
+Relative Atomic Mass = 18.99840316273(92)
+Isotopic Composition = 1
+Standard Atomic Weight = 18.998403163(6)
+Notes =
+
+Atomic Number = 10
+Atomic Symbol = Ne
+Mass Number = 20
+Relative Atomic Mass = 19.9924401762(17)
+Isotopic Composition = 0.9048(3)
+Standard Atomic Weight = 20.1797(6)
+Notes = g,m
+
+Atomic Number = 10
+Atomic Symbol = Ne
+Mass Number = 21
+Relative Atomic Mass = 20.993846685(41)
+Isotopic Composition = 0.0027(1)
+Standard Atomic Weight = 20.1797(6)
+Notes = g,m
+
+Atomic Number = 10
+Atomic Symbol = Ne
+Mass Number = 22
+Relative Atomic Mass = 21.991385114(18)
+Isotopic Composition = 0.0925(3)
+Standard Atomic Weight = 20.1797(6)
+Notes = g,m
+
+Atomic Number = 11
+Atomic Symbol = Na
+Mass Number = 23
+Relative Atomic Mass = 22.9897692820(19)
+Isotopic Composition = 1
+Standard Atomic Weight = 22.98976928(2)
+Notes =
+
+Atomic Number = 12
+Atomic Symbol = Mg
+Mass Number = 24
+Relative Atomic Mass = 23.985041697(14)
+Isotopic Composition = 0.7899(4)
+Standard Atomic Weight = [24.304,24.307]
+Notes =
+
+Atomic Number = 12
+Atomic Symbol = Mg
+Mass Number = 25
+Relative Atomic Mass = 24.985836976(50)
+Isotopic Composition = 0.1000(1)
+Standard Atomic Weight = [24.304,24.307]
+Notes =
+
+Atomic Number = 12
+Atomic Symbol = Mg
+Mass Number = 26
+Relative Atomic Mass = 25.982592968(31)
+Isotopic Composition = 0.1101(3)
+Standard Atomic Weight = [24.304,24.307]
+Notes =
+
+Atomic Number = 13
+Atomic Symbol = Al
+Mass Number = 27
+Relative Atomic Mass = 26.98153853(11)
+Isotopic Composition = 1
+Standard Atomic Weight = 26.9815385(7)
+Notes =
+
+Atomic Number = 14
+Atomic Symbol = Si
+Mass Number = 28
+Relative Atomic Mass = 27.97692653465(44)
+Isotopic Composition = 0.92223(19)
+Standard Atomic Weight = [28.084,28.086]
+Notes =
+
+Atomic Number = 14
+Atomic Symbol = Si
+Mass Number = 29
+Relative Atomic Mass = 28.97649466490(52)
+Isotopic Composition = 0.04685(8)
+Standard Atomic Weight = [28.084,28.086]
+Notes =
+
+Atomic Number = 14
+Atomic Symbol = Si
+Mass Number = 30
+Relative Atomic Mass = 29.973770136(23)
+Isotopic Composition = 0.03092(11)
+Standard Atomic Weight = [28.084,28.086]
+Notes =
+
+Atomic Number = 15
+Atomic Symbol = P
+Mass Number = 31
+Relative Atomic Mass = 30.97376199842(70)
+Isotopic Composition = 1
+Standard Atomic Weight = 30.973761998(5)
+Notes =
+
+Atomic Number = 16
+Atomic Symbol = S
+Mass Number = 32
+Relative Atomic Mass = 31.9720711744(14)
+Isotopic Composition = 0.9499(26)
+Standard Atomic Weight = [32.059,32.076]
+Notes =
+
+Atomic Number = 16
+Atomic Symbol = S
+Mass Number = 33
+Relative Atomic Mass = 32.9714589098(15)
+Isotopic Composition = 0.0075(2)
+Standard Atomic Weight = [32.059,32.076]
+Notes =
+
+Atomic Number = 16
+Atomic Symbol = S
+Mass Number = 34
+Relative Atomic Mass = 33.967867004(47)
+Isotopic Composition = 0.0425(24)
+Standard Atomic Weight = [32.059,32.076]
+Notes =
+
+Atomic Number = 16
+Atomic Symbol = S
+Mass Number = 36
+Relative Atomic Mass = 35.96708071(20)
+Isotopic Composition = 0.0001(1)
+Standard Atomic Weight = [32.059,32.076]
+Notes =
+
+Atomic Number = 17
+Atomic Symbol = Cl
+Mass Number = 35
+Relative Atomic Mass = 34.968852682(37)
+Isotopic Composition = 0.7576(10)
+Standard Atomic Weight = [35.446,35.457]
+Notes = m
+
+Atomic Number = 17
+Atomic Symbol = Cl
+Mass Number = 37
+Relative Atomic Mass = 36.965902602(55)
+Isotopic Composition = 0.2424(10)
+Standard Atomic Weight = [35.446,35.457]
+Notes = m
+
+Atomic Number = 18
+Atomic Symbol = Ar
+Mass Number = 36
+Relative Atomic Mass = 35.967545105(28)
+Isotopic Composition = 0.003336(21)
+Standard Atomic Weight = 39.948(1)
+Notes = g,r
+
+Atomic Number = 18
+Atomic Symbol = Ar
+Mass Number = 38
+Relative Atomic Mass = 37.96273211(21)
+Isotopic Composition = 0.000629(7)
+Standard Atomic Weight = 39.948(1)
+Notes = g,r
+
+Atomic Number = 18
+Atomic Symbol = Ar
+Mass Number = 40
+Relative Atomic Mass = 39.9623831237(24)
+Isotopic Composition = 0.996035(25)
+Standard Atomic Weight = 39.948(1)
+Notes = g,r
+
+Atomic Number = 19
+Atomic Symbol = K
+Mass Number = 39
+Relative Atomic Mass = 38.9637064864(49)
+Isotopic Composition = 0.932581(44)
+Standard Atomic Weight = 39.0983(1)
+Notes =
+
+Atomic Number = 19
+Atomic Symbol = K
+Mass Number = 40
+Relative Atomic Mass = 39.963998166(60)
+Isotopic Composition = 0.000117(1)
+Standard Atomic Weight = 39.0983(1)
+Notes =
+
+Atomic Number = 19
+Atomic Symbol = K
+Mass Number = 41
+Relative Atomic Mass = 40.9618252579(41)
+Isotopic Composition = 0.067302(44)
+Standard Atomic Weight = 39.0983(1)
+Notes =
+
+Atomic Number = 20
+Atomic Symbol = Ca
+Mass Number = 40
+Relative Atomic Mass = 39.962590863(22)
+Isotopic Composition = 0.96941(156)
+Standard Atomic Weight = 40.078(4)
+Notes = g
+
+Atomic Number = 20
+Atomic Symbol = Ca
+Mass Number = 42
+Relative Atomic Mass = 41.95861783(16)
+Isotopic Composition = 0.00647(23)
+Standard Atomic Weight = 40.078(4)
+Notes = g
+
+Atomic Number = 20
+Atomic Symbol = Ca
+Mass Number = 43
+Relative Atomic Mass = 42.95876644(24)
+Isotopic Composition = 0.00135(10)
+Standard Atomic Weight = 40.078(4)
+Notes = g
+
+Atomic Number = 20
+Atomic Symbol = Ca
+Mass Number = 44
+Relative Atomic Mass = 43.95548156(35)
+Isotopic Composition = 0.02086(110)
+Standard Atomic Weight = 40.078(4)
+Notes = g
+
+Atomic Number = 20
+Atomic Symbol = Ca
+Mass Number = 46
+Relative Atomic Mass = 45.9536890(24)
+Isotopic Composition = 0.00004(3)
+Standard Atomic Weight = 40.078(4)
+Notes = g
+
+Atomic Number = 20
+Atomic Symbol = Ca
+Mass Number = 48
+Relative Atomic Mass = 47.95252276(13)
+Isotopic Composition = 0.00187(21)
+Standard Atomic Weight = 40.078(4)
+Notes = g
+
+Atomic Number = 21
+Atomic Symbol = Sc
+Mass Number = 45
+Relative Atomic Mass = 44.95590828(77)
+Isotopic Composition = 1
+Standard Atomic Weight = 44.955908(5)
+Notes =
+
+Atomic Number = 22
+Atomic Symbol = Ti
+Mass Number = 46
+Relative Atomic Mass = 45.95262772(35)
+Isotopic Composition = 0.0825(3)
+Standard Atomic Weight = 47.867(1)
+Notes =
+
+Atomic Number = 22
+Atomic Symbol = Ti
+Mass Number = 47
+Relative Atomic Mass = 46.95175879(38)
+Isotopic Composition = 0.0744(2)
+Standard Atomic Weight = 47.867(1)
+Notes =
+
+Atomic Number = 22
+Atomic Symbol = Ti
+Mass Number = 48
+Relative Atomic Mass = 47.94794198(38)
+Isotopic Composition = 0.7372(3)
+Standard Atomic Weight = 47.867(1)
+Notes =
+
+Atomic Number = 22
+Atomic Symbol = Ti
+Mass Number = 49
+Relative Atomic Mass = 48.94786568(39)
+Isotopic Composition = 0.0541(2)
+Standard Atomic Weight = 47.867(1)
+Notes =
+
+Atomic Number = 22
+Atomic Symbol = Ti
+Mass Number = 50
+Relative Atomic Mass = 49.94478689(39)
+Isotopic Composition = 0.0518(2)
+Standard Atomic Weight = 47.867(1)
+Notes =
+
+Atomic Number = 23
+Atomic Symbol = V
+Mass Number = 50
+Relative Atomic Mass = 49.94715601(95)
+Isotopic Composition = 0.00250(4)
+Standard Atomic Weight = 50.9415(1)
+Notes =
+
+Atomic Number = 23
+Atomic Symbol = V
+Mass Number = 51
+Relative Atomic Mass = 50.94395704(94)
+Isotopic Composition = 0.99750(4)
+Standard Atomic Weight = 50.9415(1)
+Notes =
+
+Atomic Number = 24
+Atomic Symbol = Cr
+Mass Number = 50
+Relative Atomic Mass = 49.94604183(94)
+Isotopic Composition = 0.04345(13)
+Standard Atomic Weight = 51.9961(6)
+Notes =
+
+Atomic Number = 24
+Atomic Symbol = Cr
+Mass Number = 52
+Relative Atomic Mass = 51.94050623(63)
+Isotopic Composition = 0.83789(18)
+Standard Atomic Weight = 51.9961(6)
+Notes =
+
+Atomic Number = 24
+Atomic Symbol = Cr
+Mass Number = 53
+Relative Atomic Mass = 52.94064815(62)
+Isotopic Composition = 0.09501(17)
+Standard Atomic Weight = 51.9961(6)
+Notes =
+
+Atomic Number = 24
+Atomic Symbol = Cr
+Mass Number = 54
+Relative Atomic Mass = 53.93887916(61)
+Isotopic Composition = 0.02365(7)
+Standard Atomic Weight = 51.9961(6)
+Notes =
+
+Atomic Number = 25
+Atomic Symbol = Mn
+Mass Number = 55
+Relative Atomic Mass = 54.93804391(48)
+Isotopic Composition = 1
+Standard Atomic Weight = 54.938044(3)
+Notes =
+
+Atomic Number = 26
+Atomic Symbol = Fe
+Mass Number = 54
+Relative Atomic Mass = 53.93960899(53)
+Isotopic Composition = 0.05845(35)
+Standard Atomic Weight = 55.845(2)
+Notes =
+
+Atomic Number = 26
+Atomic Symbol = Fe
+Mass Number = 56
+Relative Atomic Mass = 55.93493633(49)
+Isotopic Composition = 0.91754(36)
+Standard Atomic Weight = 55.845(2)
+Notes =
+
+Atomic Number = 26
+Atomic Symbol = Fe
+Mass Number = 57
+Relative Atomic Mass = 56.93539284(49)
+Isotopic Composition = 0.02119(10)
+Standard Atomic Weight = 55.845(2)
+Notes =
+
+Atomic Number = 26
+Atomic Symbol = Fe
+Mass Number = 58
+Relative Atomic Mass = 57.93327443(53)
+Isotopic Composition = 0.00282(4)
+Standard Atomic Weight = 55.845(2)
+Notes =
+
+Atomic Number = 27
+Atomic Symbol = Co
+Mass Number = 59
+Relative Atomic Mass = 58.93319429(56)
+Isotopic Composition = 1
+Standard Atomic Weight = 58.933194(4)
+Notes =
+
+Atomic Number = 28
+Atomic Symbol = Ni
+Mass Number = 58
+Relative Atomic Mass = 57.93534241(52)
+Isotopic Composition = 0.68077(19)
+Standard Atomic Weight = 58.6934(4)
+Notes = r
+
+Atomic Number = 28
+Atomic Symbol = Ni
+Mass Number = 60
+Relative Atomic Mass = 59.93078588(52)
+Isotopic Composition = 0.26223(15)
+Standard Atomic Weight = 58.6934(4)
+Notes = r
+
+Atomic Number = 28
+Atomic Symbol = Ni
+Mass Number = 61
+Relative Atomic Mass = 60.93105557(52)
+Isotopic Composition = 0.011399(13)
+Standard Atomic Weight = 58.6934(4)
+Notes = r
+
+Atomic Number = 28
+Atomic Symbol = Ni
+Mass Number = 62
+Relative Atomic Mass = 61.92834537(55)
+Isotopic Composition = 0.036346(40)
+Standard Atomic Weight = 58.6934(4)
+Notes = r
+
+Atomic Number = 28
+Atomic Symbol = Ni
+Mass Number = 64
+Relative Atomic Mass = 63.92796682(58)
+Isotopic Composition = 0.009255(19)
+Standard Atomic Weight = 58.6934(4)
+Notes = r
+
+Atomic Number = 29
+Atomic Symbol = Cu
+Mass Number = 63
+Relative Atomic Mass = 62.92959772(56)
+Isotopic Composition = 0.6915(15)
+Standard Atomic Weight = 63.546(3)
+Notes = r
+
+Atomic Number = 29
+Atomic Symbol = Cu
+Mass Number = 65
+Relative Atomic Mass = 64.92778970(71)
+Isotopic Composition = 0.3085(15)
+Standard Atomic Weight = 63.546(3)
+Notes = r
+
+Atomic Number = 30
+Atomic Symbol = Zn
+Mass Number = 64
+Relative Atomic Mass = 63.92914201(71)
+Isotopic Composition = 0.4917(75)
+Standard Atomic Weight = 65.38(2)
+Notes = r
+
+Atomic Number = 30
+Atomic Symbol = Zn
+Mass Number = 66
+Relative Atomic Mass = 65.92603381(94)
+Isotopic Composition = 0.2773(98)
+Standard Atomic Weight = 65.38(2)
+Notes = r
+
+Atomic Number = 30
+Atomic Symbol = Zn
+Mass Number = 67
+Relative Atomic Mass = 66.92712775(96)
+Isotopic Composition = 0.0404(16)
+Standard Atomic Weight = 65.38(2)
+Notes = r
+
+Atomic Number = 30
+Atomic Symbol = Zn
+Mass Number = 68
+Relative Atomic Mass = 67.92484455(98)
+Isotopic Composition = 0.1845(63)
+Standard Atomic Weight = 65.38(2)
+Notes = r
+
+Atomic Number = 30
+Atomic Symbol = Zn
+Mass Number = 70
+Relative Atomic Mass = 69.9253192(21)
+Isotopic Composition = 0.0061(10)
+Standard Atomic Weight = 65.38(2)
+Notes = r
+
+Atomic Number = 31
+Atomic Symbol = Ga
+Mass Number = 69
+Relative Atomic Mass = 68.9255735(13)
+Isotopic Composition = 0.60108(9)
+Standard Atomic Weight = 69.723(1)
+Notes =
+
+Atomic Number = 31
+Atomic Symbol = Ga
+Mass Number = 71
+Relative Atomic Mass = 70.92470258(87)
+Isotopic Composition = 0.39892(9)
+Standard Atomic Weight = 69.723(1)
+Notes =
+
+Atomic Number = 32
+Atomic Symbol = Ge
+Mass Number = 70
+Relative Atomic Mass = 69.92424875(90)
+Isotopic Composition = 0.2057(27)
+Standard Atomic Weight = 72.630(8)
+Notes =
+
+Atomic Number = 32
+Atomic Symbol = Ge
+Mass Number = 72
+Relative Atomic Mass = 71.922075826(81)
+Isotopic Composition = 0.2745(32)
+Standard Atomic Weight = 72.630(8)
+Notes =
+
+Atomic Number = 32
+Atomic Symbol = Ge
+Mass Number = 73
+Relative Atomic Mass = 72.923458956(61)
+Isotopic Composition = 0.0775(12)
+Standard Atomic Weight = 72.630(8)
+Notes =
+
+Atomic Number = 32
+Atomic Symbol = Ge
+Mass Number = 74
+Relative Atomic Mass = 73.921177761(13)
+Isotopic Composition = 0.3650(20)
+Standard Atomic Weight = 72.630(8)
+Notes =
+
+Atomic Number = 32
+Atomic Symbol = Ge
+Mass Number = 76
+Relative Atomic Mass = 75.921402726(19)
+Isotopic Composition = 0.0773(12)
+Standard Atomic Weight = 72.630(8)
+Notes =
+
+Atomic Number = 33
+Atomic Symbol = As
+Mass Number = 75
+Relative Atomic Mass = 74.92159457(95)
+Isotopic Composition = 1
+Standard Atomic Weight = 74.921595(6)
+Notes =
+
+Atomic Number = 34
+Atomic Symbol = Se
+Mass Number = 74
+Relative Atomic Mass = 73.922475934(15)
+Isotopic Composition = 0.0089(4)
+Standard Atomic Weight = 78.971(8)
+Notes = r
+
+Atomic Number = 34
+Atomic Symbol = Se
+Mass Number = 76
+Relative Atomic Mass = 75.919213704(17)
+Isotopic Composition = 0.0937(29)
+Standard Atomic Weight = 78.971(8)
+Notes = r
+
+Atomic Number = 34
+Atomic Symbol = Se
+Mass Number = 77
+Relative Atomic Mass = 76.919914154(67)
+Isotopic Composition = 0.0763(16)
+Standard Atomic Weight = 78.971(8)
+Notes = r
+
+Atomic Number = 34
+Atomic Symbol = Se
+Mass Number = 78
+Relative Atomic Mass = 77.91730928(20)
+Isotopic Composition = 0.2377(28)
+Standard Atomic Weight = 78.971(8)
+Notes = r
+
+Atomic Number = 34
+Atomic Symbol = Se
+Mass Number = 80
+Relative Atomic Mass = 79.9165218(13)
+Isotopic Composition = 0.4961(41)
+Standard Atomic Weight = 78.971(8)
+Notes = r
+
+Atomic Number = 34
+Atomic Symbol = Se
+Mass Number = 82
+Relative Atomic Mass = 81.9166995(15)
+Isotopic Composition = 0.0873(22)
+Standard Atomic Weight = 78.971(8)
+Notes = r
+
+Atomic Number = 35
+Atomic Symbol = Br
+Mass Number = 79
+Relative Atomic Mass = 78.9183376(14)
+Isotopic Composition = 0.5069(7)
+Standard Atomic Weight = [79.901,79.907]
+Notes =
+
+Atomic Number = 35
+Atomic Symbol = Br
+Mass Number = 81
+Relative Atomic Mass = 80.9162897(14)
+Isotopic Composition = 0.4931(7)
+Standard Atomic Weight = [79.901,79.907]
+Notes =
+
+Atomic Number = 36
+Atomic Symbol = Kr
+Mass Number = 78
+Relative Atomic Mass = 77.92036494(76)
+Isotopic Composition = 0.00355(3)
+Standard Atomic Weight = 83.798(2)
+Notes = g,m
+
+Atomic Number = 36
+Atomic Symbol = Kr
+Mass Number = 80
+Relative Atomic Mass = 79.91637808(75)
+Isotopic Composition = 0.02286(10)
+Standard Atomic Weight = 83.798(2)
+Notes = g,m
+
+Atomic Number = 36
+Atomic Symbol = Kr
+Mass Number = 82
+Relative Atomic Mass = 81.91348273(94)
+Isotopic Composition = 0.11593(31)
+Standard Atomic Weight = 83.798(2)
+Notes = g,m
+
+Atomic Number = 36
+Atomic Symbol = Kr
+Mass Number = 83
+Relative Atomic Mass = 82.91412716(32)
+Isotopic Composition = 0.11500(19)
+Standard Atomic Weight = 83.798(2)
+Notes = g,m
+
+Atomic Number = 36
+Atomic Symbol = Kr
+Mass Number = 84
+Relative Atomic Mass = 83.9114977282(44)
+Isotopic Composition = 0.56987(15)
+Standard Atomic Weight = 83.798(2)
+Notes = g,m
+
+Atomic Number = 36
+Atomic Symbol = Kr
+Mass Number = 86
+Relative Atomic Mass = 85.9106106269(41)
+Isotopic Composition = 0.17279(41)
+Standard Atomic Weight = 83.798(2)
+Notes = g,m
+
+Atomic Number = 37
+Atomic Symbol = Rb
+Mass Number = 85
+Relative Atomic Mass = 84.9117897379(54)
+Isotopic Composition = 0.7217(2)
+Standard Atomic Weight = 85.4678(3)
+Notes = g
+
+Atomic Number = 37
+Atomic Symbol = Rb
+Mass Number = 87
+Relative Atomic Mass = 86.9091805310(60)
+Isotopic Composition = 0.2783(2)
+Standard Atomic Weight = 85.4678(3)
+Notes = g
+
+Atomic Number = 38
+Atomic Symbol = Sr
+Mass Number = 84
+Relative Atomic Mass = 83.9134191(13)
+Isotopic Composition = 0.0056(1)
+Standard Atomic Weight = 87.62(1)
+Notes = g,r
+
+Atomic Number = 38
+Atomic Symbol = Sr
+Mass Number = 86
+Relative Atomic Mass = 85.9092606(12)
+Isotopic Composition = 0.0986(1)
+Standard Atomic Weight = 87.62(1)
+Notes = g,r
+
+Atomic Number = 38
+Atomic Symbol = Sr
+Mass Number = 87
+Relative Atomic Mass = 86.9088775(12)
+Isotopic Composition = 0.0700(1)
+Standard Atomic Weight = 87.62(1)
+Notes = g,r
+
+Atomic Number = 38
+Atomic Symbol = Sr
+Mass Number = 88
+Relative Atomic Mass = 87.9056125(12)
+Isotopic Composition = 0.8258(1)
+Standard Atomic Weight = 87.62(1)
+Notes = g,r
+
+Atomic Number = 39
+Atomic Symbol = Y
+Mass Number = 89
+Relative Atomic Mass = 88.9058403(24)
+Isotopic Composition = 1
+Standard Atomic Weight = 88.90584(2)
+Notes =
+
+Atomic Number = 40
+Atomic Symbol = Zr
+Mass Number = 90
+Relative Atomic Mass = 89.9046977(20)
+Isotopic Composition = 0.5145(40)
+Standard Atomic Weight = 91.224(2)
+Notes = g
+
+Atomic Number = 40
+Atomic Symbol = Zr
+Mass Number = 91
+Relative Atomic Mass = 90.9056396(20)
+Isotopic Composition = 0.1122(5)
+Standard Atomic Weight = 91.224(2)
+Notes = g
+
+Atomic Number = 40
+Atomic Symbol = Zr
+Mass Number = 92
+Relative Atomic Mass = 91.9050347(20)
+Isotopic Composition = 0.1715(8)
+Standard Atomic Weight = 91.224(2)
+Notes = g
+
+Atomic Number = 40
+Atomic Symbol = Zr
+Mass Number = 94
+Relative Atomic Mass = 93.9063108(20)
+Isotopic Composition = 0.1738(28)
+Standard Atomic Weight = 91.224(2)
+Notes = g
+
+Atomic Number = 40
+Atomic Symbol = Zr
+Mass Number = 96
+Relative Atomic Mass = 95.9082714(21)
+Isotopic Composition = 0.0280(9)
+Standard Atomic Weight = 91.224(2)
+Notes = g
+
+Atomic Number = 41
+Atomic Symbol = Nb
+Mass Number = 93
+Relative Atomic Mass = 92.9063730(20)
+Isotopic Composition = 1
+Standard Atomic Weight = 92.90637(2)
+Notes =
+
+Atomic Number = 42
+Atomic Symbol = Mo
+Mass Number = 92
+Relative Atomic Mass = 91.90680796(84)
+Isotopic Composition = 0.1453(30)
+Standard Atomic Weight = 95.95(1)
+Notes = g
+
+Atomic Number = 42
+Atomic Symbol = Mo
+Mass Number = 94
+Relative Atomic Mass = 93.90508490(48)
+Isotopic Composition = 0.0915(9)
+Standard Atomic Weight = 95.95(1)
+Notes = g
+
+Atomic Number = 42
+Atomic Symbol = Mo
+Mass Number = 95
+Relative Atomic Mass = 94.90583877(47)
+Isotopic Composition = 0.1584(11)
+Standard Atomic Weight = 95.95(1)
+Notes = g
+
+Atomic Number = 42
+Atomic Symbol = Mo
+Mass Number = 96
+Relative Atomic Mass = 95.90467612(47)
+Isotopic Composition = 0.1667(15)
+Standard Atomic Weight = 95.95(1)
+Notes = g
+
+Atomic Number = 42
+Atomic Symbol = Mo
+Mass Number = 97
+Relative Atomic Mass = 96.90601812(49)
+Isotopic Composition = 0.0960(14)
+Standard Atomic Weight = 95.95(1)
+Notes = g
+
+Atomic Number = 42
+Atomic Symbol = Mo
+Mass Number = 98
+Relative Atomic Mass = 97.90540482(49)
+Isotopic Composition = 0.2439(37)
+Standard Atomic Weight = 95.95(1)
+Notes = g
+
+Atomic Number = 42
+Atomic Symbol = Mo
+Mass Number = 100
+Relative Atomic Mass = 99.9074718(11)
+Isotopic Composition = 0.0982(31)
+Standard Atomic Weight = 95.95(1)
+Notes = g
+
+Atomic Number = 43
+Atomic Symbol = Tc
+Mass Number = 97
+Relative Atomic Mass = 96.9063667(40)
+Isotopic Composition =
+Standard Atomic Weight = [98]
+Notes =
+
+Atomic Number = 43
+Atomic Symbol = Tc
+Mass Number = 98
+Relative Atomic Mass = 97.9072124(36)
+Isotopic Composition =
+Standard Atomic Weight = [98]
+Notes =
+
+Atomic Number = 43
+Atomic Symbol = Tc
+Mass Number = 99
+Relative Atomic Mass = 98.9062508(10)
+Isotopic Composition =
+Standard Atomic Weight = [98]
+Notes =
+
+Atomic Number = 44
+Atomic Symbol = Ru
+Mass Number = 96
+Relative Atomic Mass = 95.90759025(49)
+Isotopic Composition = 0.0554(14)
+Standard Atomic Weight = 101.07(2)
+Notes = g
+
+Atomic Number = 44
+Atomic Symbol = Ru
+Mass Number = 98
+Relative Atomic Mass = 97.9052868(69)
+Isotopic Composition = 0.0187(3)
+Standard Atomic Weight = 101.07(2)
+Notes = g
+
+Atomic Number = 44
+Atomic Symbol = Ru
+Mass Number = 99
+Relative Atomic Mass = 98.9059341(11)
+Isotopic Composition = 0.1276(14)
+Standard Atomic Weight = 101.07(2)
+Notes = g
+
+Atomic Number = 44
+Atomic Symbol = Ru
+Mass Number = 100
+Relative Atomic Mass = 99.9042143(11)
+Isotopic Composition = 0.1260(7)
+Standard Atomic Weight = 101.07(2)
+Notes = g
+
+Atomic Number = 44
+Atomic Symbol = Ru
+Mass Number = 101
+Relative Atomic Mass = 100.9055769(12)
+Isotopic Composition = 0.1706(2)
+Standard Atomic Weight = 101.07(2)
+Notes = g
+
+Atomic Number = 44
+Atomic Symbol = Ru
+Mass Number = 102
+Relative Atomic Mass = 101.9043441(12)
+Isotopic Composition = 0.3155(14)
+Standard Atomic Weight = 101.07(2)
+Notes = g
+
+Atomic Number = 44
+Atomic Symbol = Ru
+Mass Number = 104
+Relative Atomic Mass = 103.9054275(28)
+Isotopic Composition = 0.1862(27)
+Standard Atomic Weight = 101.07(2)
+Notes = g
+
+Atomic Number = 45
+Atomic Symbol = Rh
+Mass Number = 103
+Relative Atomic Mass = 102.9054980(26)
+Isotopic Composition = 1
+Standard Atomic Weight = 102.90550(2)
+Notes =
+
+Atomic Number = 46
+Atomic Symbol = Pd
+Mass Number = 102
+Relative Atomic Mass = 101.9056022(28)
+Isotopic Composition = 0.0102(1)
+Standard Atomic Weight = 106.42(1)
+Notes = g
+
+Atomic Number = 46
+Atomic Symbol = Pd
+Mass Number = 104
+Relative Atomic Mass = 103.9040305(14)
+Isotopic Composition = 0.1114(8)
+Standard Atomic Weight = 106.42(1)
+Notes = g
+
+Atomic Number = 46
+Atomic Symbol = Pd
+Mass Number = 105
+Relative Atomic Mass = 104.9050796(12)
+Isotopic Composition = 0.2233(8)
+Standard Atomic Weight = 106.42(1)
+Notes = g
+
+Atomic Number = 46
+Atomic Symbol = Pd
+Mass Number = 106
+Relative Atomic Mass = 105.9034804(12)
+Isotopic Composition = 0.2733(3)
+Standard Atomic Weight = 106.42(1)
+Notes = g
+
+Atomic Number = 46
+Atomic Symbol = Pd
+Mass Number = 108
+Relative Atomic Mass = 107.9038916(12)
+Isotopic Composition = 0.2646(9)
+Standard Atomic Weight = 106.42(1)
+Notes = g
+
+Atomic Number = 46
+Atomic Symbol = Pd
+Mass Number = 110
+Relative Atomic Mass = 109.90517220(75)
+Isotopic Composition = 0.1172(9)
+Standard Atomic Weight = 106.42(1)
+Notes = g
+
+Atomic Number = 47
+Atomic Symbol = Ag
+Mass Number = 107
+Relative Atomic Mass = 106.9050916(26)
+Isotopic Composition = 0.51839(8)
+Standard Atomic Weight = 107.8682(2)
+Notes = g
+
+Atomic Number = 47
+Atomic Symbol = Ag
+Mass Number = 109
+Relative Atomic Mass = 108.9047553(14)
+Isotopic Composition = 0.48161(8)
+Standard Atomic Weight = 107.8682(2)
+Notes = g
+
+Atomic Number = 48
+Atomic Symbol = Cd
+Mass Number = 106
+Relative Atomic Mass = 105.9064599(12)
+Isotopic Composition = 0.0125(6)
+Standard Atomic Weight = 112.414(4)
+Notes = g
+
+Atomic Number = 48
+Atomic Symbol = Cd
+Mass Number = 108
+Relative Atomic Mass = 107.9041834(12)
+Isotopic Composition = 0.0089(3)
+Standard Atomic Weight = 112.414(4)
+Notes = g
+
+Atomic Number = 48
+Atomic Symbol = Cd
+Mass Number = 110
+Relative Atomic Mass = 109.90300661(61)
+Isotopic Composition = 0.1249(18)
+Standard Atomic Weight = 112.414(4)
+Notes = g
+
+Atomic Number = 48
+Atomic Symbol = Cd
+Mass Number = 111
+Relative Atomic Mass = 110.90418287(61)
+Isotopic Composition = 0.1280(12)
+Standard Atomic Weight = 112.414(4)
+Notes = g
+
+Atomic Number = 48
+Atomic Symbol = Cd
+Mass Number = 112
+Relative Atomic Mass = 111.90276287(60)
+Isotopic Composition = 0.2413(21)
+Standard Atomic Weight = 112.414(4)
+Notes = g
+
+Atomic Number = 48
+Atomic Symbol = Cd
+Mass Number = 113
+Relative Atomic Mass = 112.90440813(45)
+Isotopic Composition = 0.1222(12)
+Standard Atomic Weight = 112.414(4)
+Notes = g
+
+Atomic Number = 48
+Atomic Symbol = Cd
+Mass Number = 114
+Relative Atomic Mass = 113.90336509(43)
+Isotopic Composition = 0.2873(42)
+Standard Atomic Weight = 112.414(4)
+Notes = g
+
+Atomic Number = 48
+Atomic Symbol = Cd
+Mass Number = 116
+Relative Atomic Mass = 115.90476315(17)
+Isotopic Composition = 0.0749(18)
+Standard Atomic Weight = 112.414(4)
+Notes = g
+
+Atomic Number = 49
+Atomic Symbol = In
+Mass Number = 113
+Relative Atomic Mass = 112.90406184(91)
+Isotopic Composition = 0.0429(5)
+Standard Atomic Weight = 114.818(1)
+Notes =
+
+Atomic Number = 49
+Atomic Symbol = In
+Mass Number = 115
+Relative Atomic Mass = 114.903878776(12)
+Isotopic Composition = 0.9571(5)
+Standard Atomic Weight = 114.818(1)
+Notes =
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 112
+Relative Atomic Mass = 111.90482387(61)
+Isotopic Composition = 0.0097(1)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 114
+Relative Atomic Mass = 113.9027827(10)
+Isotopic Composition = 0.0066(1)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 115
+Relative Atomic Mass = 114.903344699(16)
+Isotopic Composition = 0.0034(1)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 116
+Relative Atomic Mass = 115.90174280(10)
+Isotopic Composition = 0.1454(9)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 117
+Relative Atomic Mass = 116.90295398(52)
+Isotopic Composition = 0.0768(7)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 118
+Relative Atomic Mass = 117.90160657(54)
+Isotopic Composition = 0.2422(9)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 119
+Relative Atomic Mass = 118.90331117(78)
+Isotopic Composition = 0.0859(4)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 120
+Relative Atomic Mass = 119.90220163(97)
+Isotopic Composition = 0.3258(9)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 122
+Relative Atomic Mass = 121.9034438(26)
+Isotopic Composition = 0.0463(3)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 50
+Atomic Symbol = Sn
+Mass Number = 124
+Relative Atomic Mass = 123.9052766(11)
+Isotopic Composition = 0.0579(5)
+Standard Atomic Weight = 118.710(7)
+Notes = g
+
+Atomic Number = 51
+Atomic Symbol = Sb
+Mass Number = 121
+Relative Atomic Mass = 120.9038120(30)
+Isotopic Composition = 0.5721(5)
+Standard Atomic Weight = 121.760(1)
+Notes = g
+
+Atomic Number = 51
+Atomic Symbol = Sb
+Mass Number = 123
+Relative Atomic Mass = 122.9042132(23)
+Isotopic Composition = 0.4279(5)
+Standard Atomic Weight = 121.760(1)
+Notes = g
+
+Atomic Number = 52
+Atomic Symbol = Te
+Mass Number = 120
+Relative Atomic Mass = 119.9040593(33)
+Isotopic Composition = 0.0009(1)
+Standard Atomic Weight = 127.60(3)
+Notes = g
+
+Atomic Number = 52
+Atomic Symbol = Te
+Mass Number = 122
+Relative Atomic Mass = 121.9030435(16)
+Isotopic Composition = 0.0255(12)
+Standard Atomic Weight = 127.60(3)
+Notes = g
+
+Atomic Number = 52
+Atomic Symbol = Te
+Mass Number = 123
+Relative Atomic Mass = 122.9042698(16)
+Isotopic Composition = 0.0089(3)
+Standard Atomic Weight = 127.60(3)
+Notes = g
+
+Atomic Number = 52
+Atomic Symbol = Te
+Mass Number = 124
+Relative Atomic Mass = 123.9028171(16)
+Isotopic Composition = 0.0474(14)
+Standard Atomic Weight = 127.60(3)
+Notes = g
+
+Atomic Number = 52
+Atomic Symbol = Te
+Mass Number = 125
+Relative Atomic Mass = 124.9044299(16)
+Isotopic Composition = 0.0707(15)
+Standard Atomic Weight = 127.60(3)
+Notes = g
+
+Atomic Number = 52
+Atomic Symbol = Te
+Mass Number = 126
+Relative Atomic Mass = 125.9033109(16)
+Isotopic Composition = 0.1884(25)
+Standard Atomic Weight = 127.60(3)
+Notes = g
+
+Atomic Number = 52
+Atomic Symbol = Te
+Mass Number = 128
+Relative Atomic Mass = 127.90446128(93)
+Isotopic Composition = 0.3174(8)
+Standard Atomic Weight = 127.60(3)
+Notes = g
+
+Atomic Number = 52
+Atomic Symbol = Te
+Mass Number = 130
+Relative Atomic Mass = 129.906222748(12)
+Isotopic Composition = 0.3408(62)
+Standard Atomic Weight = 127.60(3)
+Notes = g
+
+Atomic Number = 53
+Atomic Symbol = I
+Mass Number = 127
+Relative Atomic Mass = 126.9044719(39)
+Isotopic Composition = 1
+Standard Atomic Weight = 126.90447(3)
+Notes =
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 124
+Relative Atomic Mass = 123.9058920(19)
+Isotopic Composition = 0.000952(3)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 126
+Relative Atomic Mass = 125.9042983(38)
+Isotopic Composition = 0.000890(2)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 128
+Relative Atomic Mass = 127.9035310(11)
+Isotopic Composition = 0.019102(8)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 129
+Relative Atomic Mass = 128.9047808611(60)
+Isotopic Composition = 0.264006(82)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 130
+Relative Atomic Mass = 129.903509349(10)
+Isotopic Composition = 0.040710(13)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 131
+Relative Atomic Mass = 130.90508406(24)
+Isotopic Composition = 0.212324(30)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 132
+Relative Atomic Mass = 131.9041550856(56)
+Isotopic Composition = 0.269086(33)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 134
+Relative Atomic Mass = 133.90539466(90)
+Isotopic Composition = 0.104357(21)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 54
+Atomic Symbol = Xe
+Mass Number = 136
+Relative Atomic Mass = 135.907214484(11)
+Isotopic Composition = 0.088573(44)
+Standard Atomic Weight = 131.293(6)
+Notes = g,m
+
+Atomic Number = 55
+Atomic Symbol = Cs
+Mass Number = 133
+Relative Atomic Mass = 132.9054519610(80)
+Isotopic Composition = 1
+Standard Atomic Weight = 132.90545196(6)
+Notes =
+
+Atomic Number = 56
+Atomic Symbol = Ba
+Mass Number = 130
+Relative Atomic Mass = 129.9063207(28)
+Isotopic Composition = 0.00106(1)
+Standard Atomic Weight = 137.327(7)
+Notes =
+
+Atomic Number = 56
+Atomic Symbol = Ba
+Mass Number = 132
+Relative Atomic Mass = 131.9050611(11)
+Isotopic Composition = 0.00101(1)
+Standard Atomic Weight = 137.327(7)
+Notes =
+
+Atomic Number = 56
+Atomic Symbol = Ba
+Mass Number = 134
+Relative Atomic Mass = 133.90450818(30)
+Isotopic Composition = 0.02417(18)
+Standard Atomic Weight = 137.327(7)
+Notes =
+
+Atomic Number = 56
+Atomic Symbol = Ba
+Mass Number = 135
+Relative Atomic Mass = 134.90568838(29)
+Isotopic Composition = 0.06592(12)
+Standard Atomic Weight = 137.327(7)
+Notes =
+
+Atomic Number = 56
+Atomic Symbol = Ba
+Mass Number = 136
+Relative Atomic Mass = 135.90457573(29)
+Isotopic Composition = 0.07854(24)
+Standard Atomic Weight = 137.327(7)
+Notes =
+
+Atomic Number = 56
+Atomic Symbol = Ba
+Mass Number = 137
+Relative Atomic Mass = 136.90582714(30)
+Isotopic Composition = 0.11232(24)
+Standard Atomic Weight = 137.327(7)
+Notes =
+
+Atomic Number = 56
+Atomic Symbol = Ba
+Mass Number = 138
+Relative Atomic Mass = 137.90524700(31)
+Isotopic Composition = 0.71698(42)
+Standard Atomic Weight = 137.327(7)
+Notes =
+
+Atomic Number = 57
+Atomic Symbol = La
+Mass Number = 138
+Relative Atomic Mass = 137.9071149(37)
+Isotopic Composition = 0.0008881(71)
+Standard Atomic Weight = 138.90547(7)
+Notes = g
+
+Atomic Number = 57
+Atomic Symbol = La
+Mass Number = 139
+Relative Atomic Mass = 138.9063563(24)
+Isotopic Composition = 0.9991119(71)
+Standard Atomic Weight = 138.90547(7)
+Notes = g
+
+Atomic Number = 58
+Atomic Symbol = Ce
+Mass Number = 136
+Relative Atomic Mass = 135.90712921(41)
+Isotopic Composition = 0.00185(2)
+Standard Atomic Weight = 140.116(1)
+Notes = g
+
+Atomic Number = 58
+Atomic Symbol = Ce
+Mass Number = 138
+Relative Atomic Mass = 137.905991(11)
+Isotopic Composition = 0.00251(2)
+Standard Atomic Weight = 140.116(1)
+Notes = g
+
+Atomic Number = 58
+Atomic Symbol = Ce
+Mass Number = 140
+Relative Atomic Mass = 139.9054431(23)
+Isotopic Composition = 0.88450(51)
+Standard Atomic Weight = 140.116(1)
+Notes = g
+
+Atomic Number = 58
+Atomic Symbol = Ce
+Mass Number = 142
+Relative Atomic Mass = 141.9092504(29)
+Isotopic Composition = 0.11114(51)
+Standard Atomic Weight = 140.116(1)
+Notes = g
+
+Atomic Number = 59
+Atomic Symbol = Pr
+Mass Number = 141
+Relative Atomic Mass = 140.9076576(23)
+Isotopic Composition = 1
+Standard Atomic Weight = 140.90766(2)
+Notes =
+
+Atomic Number = 60
+Atomic Symbol = Nd
+Mass Number = 142
+Relative Atomic Mass = 141.9077290(20)
+Isotopic Composition = 0.27152(40)
+Standard Atomic Weight = 144.242(3)
+Notes = g
+
+Atomic Number = 60
+Atomic Symbol = Nd
+Mass Number = 143
+Relative Atomic Mass = 142.9098200(20)
+Isotopic Composition = 0.12174(26)
+Standard Atomic Weight = 144.242(3)
+Notes = g
+
+Atomic Number = 60
+Atomic Symbol = Nd
+Mass Number = 144
+Relative Atomic Mass = 143.9100930(20)
+Isotopic Composition = 0.23798(19)
+Standard Atomic Weight = 144.242(3)
+Notes = g
+
+Atomic Number = 60
+Atomic Symbol = Nd
+Mass Number = 145
+Relative Atomic Mass = 144.9125793(20)
+Isotopic Composition = 0.08293(12)
+Standard Atomic Weight = 144.242(3)
+Notes = g
+
+Atomic Number = 60
+Atomic Symbol = Nd
+Mass Number = 146
+Relative Atomic Mass = 145.9131226(20)
+Isotopic Composition = 0.17189(32)
+Standard Atomic Weight = 144.242(3)
+Notes = g
+
+Atomic Number = 60
+Atomic Symbol = Nd
+Mass Number = 148
+Relative Atomic Mass = 147.9168993(26)
+Isotopic Composition = 0.05756(21)
+Standard Atomic Weight = 144.242(3)
+Notes = g
+
+Atomic Number = 60
+Atomic Symbol = Nd
+Mass Number = 150
+Relative Atomic Mass = 149.9209022(18)
+Isotopic Composition = 0.05638(28)
+Standard Atomic Weight = 144.242(3)
+Notes = g
+
+Atomic Number = 61
+Atomic Symbol = Pm
+Mass Number = 145
+Relative Atomic Mass = 144.9127559(33)
+Isotopic Composition =
+Standard Atomic Weight = [145]
+Notes =
+
+Atomic Number = 61
+Atomic Symbol = Pm
+Mass Number = 147
+Relative Atomic Mass = 146.9151450(19)
+Isotopic Composition =
+Standard Atomic Weight = [145]
+Notes =
+
+Atomic Number = 62
+Atomic Symbol = Sm
+Mass Number = 144
+Relative Atomic Mass = 143.9120065(21)
+Isotopic Composition = 0.0307(7)
+Standard Atomic Weight = 150.36(2)
+Notes = g
+
+Atomic Number = 62
+Atomic Symbol = Sm
+Mass Number = 147
+Relative Atomic Mass = 146.9149044(19)
+Isotopic Composition = 0.1499(18)
+Standard Atomic Weight = 150.36(2)
+Notes = g
+
+Atomic Number = 62
+Atomic Symbol = Sm
+Mass Number = 148
+Relative Atomic Mass = 147.9148292(19)
+Isotopic Composition = 0.1124(10)
+Standard Atomic Weight = 150.36(2)
+Notes = g
+
+Atomic Number = 62
+Atomic Symbol = Sm
+Mass Number = 149
+Relative Atomic Mass = 148.9171921(18)
+Isotopic Composition = 0.1382(7)
+Standard Atomic Weight = 150.36(2)
+Notes = g
+
+Atomic Number = 62
+Atomic Symbol = Sm
+Mass Number = 150
+Relative Atomic Mass = 149.9172829(18)
+Isotopic Composition = 0.0738(1)
+Standard Atomic Weight = 150.36(2)
+Notes = g
+
+Atomic Number = 62
+Atomic Symbol = Sm
+Mass Number = 152
+Relative Atomic Mass = 151.9197397(18)
+Isotopic Composition = 0.2675(16)
+Standard Atomic Weight = 150.36(2)
+Notes = g
+
+Atomic Number = 62
+Atomic Symbol = Sm
+Mass Number = 154
+Relative Atomic Mass = 153.9222169(20)
+Isotopic Composition = 0.2275(29)
+Standard Atomic Weight = 150.36(2)
+Notes = g
+
+Atomic Number = 63
+Atomic Symbol = Eu
+Mass Number = 151
+Relative Atomic Mass = 150.9198578(18)
+Isotopic Composition = 0.4781(6)
+Standard Atomic Weight = 151.964(1)
+Notes = g
+
+Atomic Number = 63
+Atomic Symbol = Eu
+Mass Number = 153
+Relative Atomic Mass = 152.9212380(18)
+Isotopic Composition = 0.5219(6)
+Standard Atomic Weight = 151.964(1)
+Notes = g
+
+Atomic Number = 64
+Atomic Symbol = Gd
+Mass Number = 152
+Relative Atomic Mass = 151.9197995(18)
+Isotopic Composition = 0.0020(1)
+Standard Atomic Weight = 157.25(3)
+Notes = g
+
+Atomic Number = 64
+Atomic Symbol = Gd
+Mass Number = 154
+Relative Atomic Mass = 153.9208741(17)
+Isotopic Composition = 0.0218(3)
+Standard Atomic Weight = 157.25(3)
+Notes = g
+
+Atomic Number = 64
+Atomic Symbol = Gd
+Mass Number = 155
+Relative Atomic Mass = 154.9226305(17)
+Isotopic Composition = 0.1480(12)
+Standard Atomic Weight = 157.25(3)
+Notes = g
+
+Atomic Number = 64
+Atomic Symbol = Gd
+Mass Number = 156
+Relative Atomic Mass = 155.9221312(17)
+Isotopic Composition = 0.2047(9)
+Standard Atomic Weight = 157.25(3)
+Notes = g
+
+Atomic Number = 64
+Atomic Symbol = Gd
+Mass Number = 157
+Relative Atomic Mass = 156.9239686(17)
+Isotopic Composition = 0.1565(2)
+Standard Atomic Weight = 157.25(3)
+Notes = g
+
+Atomic Number = 64
+Atomic Symbol = Gd
+Mass Number = 158
+Relative Atomic Mass = 157.9241123(17)
+Isotopic Composition = 0.2484(7)
+Standard Atomic Weight = 157.25(3)
+Notes = g
+
+Atomic Number = 64
+Atomic Symbol = Gd
+Mass Number = 160
+Relative Atomic Mass = 159.9270624(18)
+Isotopic Composition = 0.2186(19)
+Standard Atomic Weight = 157.25(3)
+Notes = g
+
+Atomic Number = 65
+Atomic Symbol = Tb
+Mass Number = 159
+Relative Atomic Mass = 158.9253547(19)
+Isotopic Composition = 1
+Standard Atomic Weight = 158.92535(2)
+Notes =
+
+Atomic Number = 66
+Atomic Symbol = Dy
+Mass Number = 156
+Relative Atomic Mass = 155.9242847(17)
+Isotopic Composition = 0.00056(3)
+Standard Atomic Weight = 162.500(1)
+Notes = g
+
+Atomic Number = 66
+Atomic Symbol = Dy
+Mass Number = 158
+Relative Atomic Mass = 157.9244159(31)
+Isotopic Composition = 0.00095(3)
+Standard Atomic Weight = 162.500(1)
+Notes = g
+
+Atomic Number = 66
+Atomic Symbol = Dy
+Mass Number = 160
+Relative Atomic Mass = 159.9252046(20)
+Isotopic Composition = 0.02329(18)
+Standard Atomic Weight = 162.500(1)
+Notes = g
+
+Atomic Number = 66
+Atomic Symbol = Dy
+Mass Number = 161
+Relative Atomic Mass = 160.9269405(20)
+Isotopic Composition = 0.18889(42)
+Standard Atomic Weight = 162.500(1)
+Notes = g
+
+Atomic Number = 66
+Atomic Symbol = Dy
+Mass Number = 162
+Relative Atomic Mass = 161.9268056(20)
+Isotopic Composition = 0.25475(36)
+Standard Atomic Weight = 162.500(1)
+Notes = g
+
+Atomic Number = 66
+Atomic Symbol = Dy
+Mass Number = 163
+Relative Atomic Mass = 162.9287383(20)
+Isotopic Composition = 0.24896(42)
+Standard Atomic Weight = 162.500(1)
+Notes = g
+
+Atomic Number = 66
+Atomic Symbol = Dy
+Mass Number = 164
+Relative Atomic Mass = 163.9291819(20)
+Isotopic Composition = 0.28260(54)
+Standard Atomic Weight = 162.500(1)
+Notes = g
+
+Atomic Number = 67
+Atomic Symbol = Ho
+Mass Number = 165
+Relative Atomic Mass = 164.9303288(21)
+Isotopic Composition = 1
+Standard Atomic Weight = 164.93033(2)
+Notes =
+
+Atomic Number = 68
+Atomic Symbol = Er
+Mass Number = 162
+Relative Atomic Mass = 161.9287884(20)
+Isotopic Composition = 0.00139(5)
+Standard Atomic Weight = 167.259(3)
+Notes = g
+
+Atomic Number = 68
+Atomic Symbol = Er
+Mass Number = 164
+Relative Atomic Mass = 163.9292088(20)
+Isotopic Composition = 0.01601(3)
+Standard Atomic Weight = 167.259(3)
+Notes = g
+
+Atomic Number = 68
+Atomic Symbol = Er
+Mass Number = 166
+Relative Atomic Mass = 165.9302995(22)
+Isotopic Composition = 0.33503(36)
+Standard Atomic Weight = 167.259(3)
+Notes = g
+
+Atomic Number = 68
+Atomic Symbol = Er
+Mass Number = 167
+Relative Atomic Mass = 166.9320546(22)
+Isotopic Composition = 0.22869(9)
+Standard Atomic Weight = 167.259(3)
+Notes = g
+
+Atomic Number = 68
+Atomic Symbol = Er
+Mass Number = 168
+Relative Atomic Mass = 167.9323767(22)
+Isotopic Composition = 0.26978(18)
+Standard Atomic Weight = 167.259(3)
+Notes = g
+
+Atomic Number = 68
+Atomic Symbol = Er
+Mass Number = 170
+Relative Atomic Mass = 169.9354702(26)
+Isotopic Composition = 0.14910(36)
+Standard Atomic Weight = 167.259(3)
+Notes = g
+
+Atomic Number = 69
+Atomic Symbol = Tm
+Mass Number = 169
+Relative Atomic Mass = 168.9342179(22)
+Isotopic Composition = 1
+Standard Atomic Weight = 168.93422(2)
+Notes =
+
+Atomic Number = 70
+Atomic Symbol = Yb
+Mass Number = 168
+Relative Atomic Mass = 167.9338896(22)
+Isotopic Composition = 0.00123(3)
+Standard Atomic Weight = 173.054(5)
+Notes = g
+
+Atomic Number = 70
+Atomic Symbol = Yb
+Mass Number = 170
+Relative Atomic Mass = 169.9347664(22)
+Isotopic Composition = 0.02982(39)
+Standard Atomic Weight = 173.054(5)
+Notes = g
+
+Atomic Number = 70
+Atomic Symbol = Yb
+Mass Number = 171
+Relative Atomic Mass = 170.9363302(22)
+Isotopic Composition = 0.1409(14)
+Standard Atomic Weight = 173.054(5)
+Notes = g
+
+Atomic Number = 70
+Atomic Symbol = Yb
+Mass Number = 172
+Relative Atomic Mass = 171.9363859(22)
+Isotopic Composition = 0.2168(13)
+Standard Atomic Weight = 173.054(5)
+Notes = g
+
+Atomic Number = 70
+Atomic Symbol = Yb
+Mass Number = 173
+Relative Atomic Mass = 172.9382151(22)
+Isotopic Composition = 0.16103(63)
+Standard Atomic Weight = 173.054(5)
+Notes = g
+
+Atomic Number = 70
+Atomic Symbol = Yb
+Mass Number = 174
+Relative Atomic Mass = 173.9388664(22)
+Isotopic Composition = 0.32026(80)
+Standard Atomic Weight = 173.054(5)
+Notes = g
+
+Atomic Number = 70
+Atomic Symbol = Yb
+Mass Number = 176
+Relative Atomic Mass = 175.9425764(24)
+Isotopic Composition = 0.12996(83)
+Standard Atomic Weight = 173.054(5)
+Notes = g
+
+Atomic Number = 71
+Atomic Symbol = Lu
+Mass Number = 175
+Relative Atomic Mass = 174.9407752(20)
+Isotopic Composition = 0.97401(13)
+Standard Atomic Weight = 174.9668(1)
+Notes = g
+
+Atomic Number = 71
+Atomic Symbol = Lu
+Mass Number = 176
+Relative Atomic Mass = 175.9426897(20)
+Isotopic Composition = 0.02599(13)
+Standard Atomic Weight = 174.9668(1)
+Notes = g
+
+Atomic Number = 72
+Atomic Symbol = Hf
+Mass Number = 174
+Relative Atomic Mass = 173.9400461(28)
+Isotopic Composition = 0.0016(1)
+Standard Atomic Weight = 178.49(2)
+Notes =
+
+Atomic Number = 72
+Atomic Symbol = Hf
+Mass Number = 176
+Relative Atomic Mass = 175.9414076(22)
+Isotopic Composition = 0.0526(7)
+Standard Atomic Weight = 178.49(2)
+Notes =
+
+Atomic Number = 72
+Atomic Symbol = Hf
+Mass Number = 177
+Relative Atomic Mass = 176.9432277(20)
+Isotopic Composition = 0.1860(9)
+Standard Atomic Weight = 178.49(2)
+Notes =
+
+Atomic Number = 72
+Atomic Symbol = Hf
+Mass Number = 178
+Relative Atomic Mass = 177.9437058(20)
+Isotopic Composition = 0.2728(7)
+Standard Atomic Weight = 178.49(2)
+Notes =
+
+Atomic Number = 72
+Atomic Symbol = Hf
+Mass Number = 179
+Relative Atomic Mass = 178.9458232(20)
+Isotopic Composition = 0.1362(2)
+Standard Atomic Weight = 178.49(2)
+Notes =
+
+Atomic Number = 72
+Atomic Symbol = Hf
+Mass Number = 180
+Relative Atomic Mass = 179.9465570(20)
+Isotopic Composition = 0.3508(16)
+Standard Atomic Weight = 178.49(2)
+Notes =
+
+Atomic Number = 73
+Atomic Symbol = Ta
+Mass Number = 180
+Relative Atomic Mass = 179.9474648(24)
+Isotopic Composition = 0.0001201(32)
+Standard Atomic Weight = 180.94788(2)
+Notes =
+
+Atomic Number = 73
+Atomic Symbol = Ta
+Mass Number = 181
+Relative Atomic Mass = 180.9479958(20)
+Isotopic Composition = 0.9998799(32)
+Standard Atomic Weight = 180.94788(2)
+Notes =
+
+Atomic Number = 74
+Atomic Symbol = W
+Mass Number = 180
+Relative Atomic Mass = 179.9467108(20)
+Isotopic Composition = 0.0012(1)
+Standard Atomic Weight = 183.84(1)
+Notes =
+
+Atomic Number = 74
+Atomic Symbol = W
+Mass Number = 182
+Relative Atomic Mass = 181.94820394(91)
+Isotopic Composition = 0.2650(16)
+Standard Atomic Weight = 183.84(1)
+Notes =
+
+Atomic Number = 74
+Atomic Symbol = W
+Mass Number = 183
+Relative Atomic Mass = 182.95022275(90)
+Isotopic Composition = 0.1431(4)
+Standard Atomic Weight = 183.84(1)
+Notes =
+
+Atomic Number = 74
+Atomic Symbol = W
+Mass Number = 184
+Relative Atomic Mass = 183.95093092(94)
+Isotopic Composition = 0.3064(2)
+Standard Atomic Weight = 183.84(1)
+Notes =
+
+Atomic Number = 74
+Atomic Symbol = W
+Mass Number = 186
+Relative Atomic Mass = 185.9543628(17)
+Isotopic Composition = 0.2843(19)
+Standard Atomic Weight = 183.84(1)
+Notes =
+
+Atomic Number = 75
+Atomic Symbol = Re
+Mass Number = 185
+Relative Atomic Mass = 184.9529545(13)
+Isotopic Composition = 0.3740(2)
+Standard Atomic Weight = 186.207(1)
+Notes =
+
+Atomic Number = 75
+Atomic Symbol = Re
+Mass Number = 187
+Relative Atomic Mass = 186.9557501(16)
+Isotopic Composition = 0.6260(2)
+Standard Atomic Weight = 186.207(1)
+Notes =
+
+Atomic Number = 76
+Atomic Symbol = Os
+Mass Number = 184
+Relative Atomic Mass = 183.9524885(14)
+Isotopic Composition = 0.0002(1)
+Standard Atomic Weight = 190.23(3)
+Notes = g
+
+Atomic Number = 76
+Atomic Symbol = Os
+Mass Number = 186
+Relative Atomic Mass = 185.9538350(16)
+Isotopic Composition = 0.0159(3)
+Standard Atomic Weight = 190.23(3)
+Notes = g
+
+Atomic Number = 76
+Atomic Symbol = Os
+Mass Number = 187
+Relative Atomic Mass = 186.9557474(16)
+Isotopic Composition = 0.0196(2)
+Standard Atomic Weight = 190.23(3)
+Notes = g
+
+Atomic Number = 76
+Atomic Symbol = Os
+Mass Number = 188
+Relative Atomic Mass = 187.9558352(16)
+Isotopic Composition = 0.1324(8)
+Standard Atomic Weight = 190.23(3)
+Notes = g
+
+Atomic Number = 76
+Atomic Symbol = Os
+Mass Number = 189
+Relative Atomic Mass = 188.9581442(17)
+Isotopic Composition = 0.1615(5)
+Standard Atomic Weight = 190.23(3)
+Notes = g
+
+Atomic Number = 76
+Atomic Symbol = Os
+Mass Number = 190
+Relative Atomic Mass = 189.9584437(17)
+Isotopic Composition = 0.2626(2)
+Standard Atomic Weight = 190.23(3)
+Notes = g
+
+Atomic Number = 76
+Atomic Symbol = Os
+Mass Number = 192
+Relative Atomic Mass = 191.9614770(29)
+Isotopic Composition = 0.4078(19)
+Standard Atomic Weight = 190.23(3)
+Notes = g
+
+Atomic Number = 77
+Atomic Symbol = Ir
+Mass Number = 191
+Relative Atomic Mass = 190.9605893(21)
+Isotopic Composition = 0.373(2)
+Standard Atomic Weight = 192.217(3)
+Notes =
+
+Atomic Number = 77
+Atomic Symbol = Ir
+Mass Number = 193
+Relative Atomic Mass = 192.9629216(21)
+Isotopic Composition = 0.627(2)
+Standard Atomic Weight = 192.217(3)
+Notes =
+
+Atomic Number = 78
+Atomic Symbol = Pt
+Mass Number = 190
+Relative Atomic Mass = 189.9599297(63)
+Isotopic Composition = 0.00012(2)
+Standard Atomic Weight = 195.084(9)
+Notes =
+
+Atomic Number = 78
+Atomic Symbol = Pt
+Mass Number = 192
+Relative Atomic Mass = 191.9610387(32)
+Isotopic Composition = 0.00782(24)
+Standard Atomic Weight = 195.084(9)
+Notes =
+
+Atomic Number = 78
+Atomic Symbol = Pt
+Mass Number = 194
+Relative Atomic Mass = 193.9626809(10)
+Isotopic Composition = 0.3286(40)
+Standard Atomic Weight = 195.084(9)
+Notes =
+
+Atomic Number = 78
+Atomic Symbol = Pt
+Mass Number = 195
+Relative Atomic Mass = 194.9647917(10)
+Isotopic Composition = 0.3378(24)
+Standard Atomic Weight = 195.084(9)
+Notes =
+
+Atomic Number = 78
+Atomic Symbol = Pt
+Mass Number = 196
+Relative Atomic Mass = 195.96495209(99)
+Isotopic Composition = 0.2521(34)
+Standard Atomic Weight = 195.084(9)
+Notes =
+
+Atomic Number = 78
+Atomic Symbol = Pt
+Mass Number = 198
+Relative Atomic Mass = 197.9678949(23)
+Isotopic Composition = 0.07356(130)
+Standard Atomic Weight = 195.084(9)
+Notes =
+
+Atomic Number = 79
+Atomic Symbol = Au
+Mass Number = 197
+Relative Atomic Mass = 196.96656879(71)
+Isotopic Composition = 1
+Standard Atomic Weight = 196.966569(5)
+Notes =
+
+Atomic Number = 80
+Atomic Symbol = Hg
+Mass Number = 196
+Relative Atomic Mass = 195.9658326(32)
+Isotopic Composition = 0.0015(1)
+Standard Atomic Weight = 200.592(3)
+Notes =
+
+Atomic Number = 80
+Atomic Symbol = Hg
+Mass Number = 198
+Relative Atomic Mass = 197.96676860(52)
+Isotopic Composition = 0.0997(20)
+Standard Atomic Weight = 200.592(3)
+Notes =
+
+Atomic Number = 80
+Atomic Symbol = Hg
+Mass Number = 199
+Relative Atomic Mass = 198.96828064(46)
+Isotopic Composition = 0.1687(22)
+Standard Atomic Weight = 200.592(3)
+Notes =
+
+Atomic Number = 80
+Atomic Symbol = Hg
+Mass Number = 200
+Relative Atomic Mass = 199.96832659(47)
+Isotopic Composition = 0.2310(19)
+Standard Atomic Weight = 200.592(3)
+Notes =
+
+Atomic Number = 80
+Atomic Symbol = Hg
+Mass Number = 201
+Relative Atomic Mass = 200.97030284(69)
+Isotopic Composition = 0.1318(9)
+Standard Atomic Weight = 200.592(3)
+Notes =
+
+Atomic Number = 80
+Atomic Symbol = Hg
+Mass Number = 202
+Relative Atomic Mass = 201.97064340(69)
+Isotopic Composition = 0.2986(26)
+Standard Atomic Weight = 200.592(3)
+Notes =
+
+Atomic Number = 80
+Atomic Symbol = Hg
+Mass Number = 204
+Relative Atomic Mass = 203.97349398(53)
+Isotopic Composition = 0.0687(15)
+Standard Atomic Weight = 200.592(3)
+Notes =
+
+Atomic Number = 81
+Atomic Symbol = Tl
+Mass Number = 203
+Relative Atomic Mass = 202.9723446(14)
+Isotopic Composition = 0.2952(1)
+Standard Atomic Weight = [204.382,204.385]
+Notes =
+
+Atomic Number = 81
+Atomic Symbol = Tl
+Mass Number = 205
+Relative Atomic Mass = 204.9744278(14)
+Isotopic Composition = 0.7048(1)
+Standard Atomic Weight = [204.382,204.385]
+Notes =
+
+Atomic Number = 82
+Atomic Symbol = Pb
+Mass Number = 204
+Relative Atomic Mass = 203.9730440(13)
+Isotopic Composition = 0.014(1)
+Standard Atomic Weight = 207.2(1)
+Notes = g,r
+
+Atomic Number = 82
+Atomic Symbol = Pb
+Mass Number = 206
+Relative Atomic Mass = 205.9744657(13)
+Isotopic Composition = 0.241(1)
+Standard Atomic Weight = 207.2(1)
+Notes = g,r
+
+Atomic Number = 82
+Atomic Symbol = Pb
+Mass Number = 207
+Relative Atomic Mass = 206.9758973(13)
+Isotopic Composition = 0.221(1)
+Standard Atomic Weight = 207.2(1)
+Notes = g,r
+
+Atomic Number = 82
+Atomic Symbol = Pb
+Mass Number = 208
+Relative Atomic Mass = 207.9766525(13)
+Isotopic Composition = 0.524(1)
+Standard Atomic Weight = 207.2(1)
+Notes = g,r
+
+Atomic Number = 83
+Atomic Symbol = Bi
+Mass Number = 209
+Relative Atomic Mass = 208.9803991(16)
+Isotopic Composition = 1
+Standard Atomic Weight = 208.98040(1)
+Notes =
+
+Atomic Number = 84
+Atomic Symbol = Po
+Mass Number = 209
+Relative Atomic Mass = 208.9824308(20)
+Isotopic Composition =
+Standard Atomic Weight = [209]
+Notes =
+
+Atomic Number = 84
+Atomic Symbol = Po
+Mass Number = 210
+Relative Atomic Mass = 209.9828741(13)
+Isotopic Composition =
+Standard Atomic Weight = [209]
+Notes =
+
+Atomic Number = 85
+Atomic Symbol = At
+Mass Number = 210
+Relative Atomic Mass = 209.9871479(83)
+Isotopic Composition =
+Standard Atomic Weight = [210]
+Notes =
+
+Atomic Number = 85
+Atomic Symbol = At
+Mass Number = 211
+Relative Atomic Mass = 210.9874966(30)
+Isotopic Composition =
+Standard Atomic Weight = [210]
+Notes =
+
+Atomic Number = 86
+Atomic Symbol = Rn
+Mass Number = 211
+Relative Atomic Mass = 210.9906011(73)
+Isotopic Composition =
+Standard Atomic Weight = [222]
+Notes =
+
+Atomic Number = 86
+Atomic Symbol = Rn
+Mass Number = 220
+Relative Atomic Mass = 220.0113941(23)
+Isotopic Composition =
+Standard Atomic Weight = [222]
+Notes =
+
+Atomic Number = 86
+Atomic Symbol = Rn
+Mass Number = 222
+Relative Atomic Mass = 222.0175782(25)
+Isotopic Composition =
+Standard Atomic Weight = [222]
+Notes =
+
+Atomic Number = 87
+Atomic Symbol = Fr
+Mass Number = 223
+Relative Atomic Mass = 223.0197360(25)
+Isotopic Composition =
+Standard Atomic Weight = [223]
+Notes =
+
+Atomic Number = 88
+Atomic Symbol = Ra
+Mass Number = 223
+Relative Atomic Mass = 223.0185023(27)
+Isotopic Composition =
+Standard Atomic Weight = [226]
+Notes =
+
+Atomic Number = 88
+Atomic Symbol = Ra
+Mass Number = 224
+Relative Atomic Mass = 224.0202120(23)
+Isotopic Composition =
+Standard Atomic Weight = [226]
+Notes =
+
+Atomic Number = 88
+Atomic Symbol = Ra
+Mass Number = 226
+Relative Atomic Mass = 226.0254103(25)
+Isotopic Composition =
+Standard Atomic Weight = [226]
+Notes =
+
+Atomic Number = 88
+Atomic Symbol = Ra
+Mass Number = 228
+Relative Atomic Mass = 228.0310707(26)
+Isotopic Composition =
+Standard Atomic Weight = [226]
+Notes =
+
+Atomic Number = 89
+Atomic Symbol = Ac
+Mass Number = 227
+Relative Atomic Mass = 227.0277523(25)
+Isotopic Composition =
+Standard Atomic Weight = [227]
+Notes =
+
+Atomic Number = 90
+Atomic Symbol = Th
+Mass Number = 230
+Relative Atomic Mass = 230.0331341(19)
+Isotopic Composition =
+Standard Atomic Weight = 232.0377(4)
+Notes = g
+
+Atomic Number = 90
+Atomic Symbol = Th
+Mass Number = 232
+Relative Atomic Mass = 232.0380558(21)
+Isotopic Composition = 1
+Standard Atomic Weight = 232.0377(4)
+Notes = g
+
+Atomic Number = 91
+Atomic Symbol = Pa
+Mass Number = 231
+Relative Atomic Mass = 231.0358842(24)
+Isotopic Composition = 1
+Standard Atomic Weight = 231.03588(2)
+Notes =
+
+Atomic Number = 92
+Atomic Symbol = U
+Mass Number = 233
+Relative Atomic Mass = 233.0396355(29)
+Isotopic Composition =
+Standard Atomic Weight = 238.02891(3)
+Notes = g,m
+
+Atomic Number = 92
+Atomic Symbol = U
+Mass Number = 234
+Relative Atomic Mass = 234.0409523(19)
+Isotopic Composition = 0.000054(5)
+Standard Atomic Weight = 238.02891(3)
+Notes = g,m
+
+Atomic Number = 92
+Atomic Symbol = U
+Mass Number = 235
+Relative Atomic Mass = 235.0439301(19)
+Isotopic Composition = 0.007204(6)
+Standard Atomic Weight = 238.02891(3)
+Notes = g,m
+
+Atomic Number = 92
+Atomic Symbol = U
+Mass Number = 236
+Relative Atomic Mass = 236.0455682(19)
+Isotopic Composition =
+Standard Atomic Weight = 238.02891(3)
+Notes = g,m
+
+Atomic Number = 92
+Atomic Symbol = U
+Mass Number = 238
+Relative Atomic Mass = 238.0507884(20)
+Isotopic Composition = 0.992742(10)
+Standard Atomic Weight = 238.02891(3)
+Notes = g,m
+
+Atomic Number = 93
+Atomic Symbol = Np
+Mass Number = 236
+Relative Atomic Mass = 236.046570(54)
+Isotopic Composition =
+Standard Atomic Weight = [237]
+Notes =
+
+Atomic Number = 93
+Atomic Symbol = Np
+Mass Number = 237
+Relative Atomic Mass = 237.0481736(19)
+Isotopic Composition =
+Standard Atomic Weight = [237]
+Notes =
+
+Atomic Number = 94
+Atomic Symbol = Pu
+Mass Number = 238
+Relative Atomic Mass = 238.0495601(19)
+Isotopic Composition =
+Standard Atomic Weight = [244]
+Notes =
+
+Atomic Number = 94
+Atomic Symbol = Pu
+Mass Number = 239
+Relative Atomic Mass = 239.0521636(19)
+Isotopic Composition =
+Standard Atomic Weight = [244]
+Notes =
+
+Atomic Number = 94
+Atomic Symbol = Pu
+Mass Number = 240
+Relative Atomic Mass = 240.0538138(19)
+Isotopic Composition =
+Standard Atomic Weight = [244]
+Notes =
+
+Atomic Number = 94
+Atomic Symbol = Pu
+Mass Number = 241
+Relative Atomic Mass = 241.0568517(19)
+Isotopic Composition =
+Standard Atomic Weight = [244]
+Notes =
+
+Atomic Number = 94
+Atomic Symbol = Pu
+Mass Number = 242
+Relative Atomic Mass = 242.0587428(20)
+Isotopic Composition =
+Standard Atomic Weight = [244]
+Notes =
+
+Atomic Number = 94
+Atomic Symbol = Pu
+Mass Number = 244
+Relative Atomic Mass = 244.0642053(56)
+Isotopic Composition =
+Standard Atomic Weight = [244]
+Notes =
+
+Atomic Number = 95
+Atomic Symbol = Am
+Mass Number = 241
+Relative Atomic Mass = 241.0568293(19)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 95
+Atomic Symbol = Am
+Mass Number = 243
+Relative Atomic Mass = 243.0613813(24)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 96
+Atomic Symbol = Cm
+Mass Number = 243
+Relative Atomic Mass = 243.0613893(22)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 96
+Atomic Symbol = Cm
+Mass Number = 244
+Relative Atomic Mass = 244.0627528(19)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 96
+Atomic Symbol = Cm
+Mass Number = 245
+Relative Atomic Mass = 245.0654915(22)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 96
+Atomic Symbol = Cm
+Mass Number = 246
+Relative Atomic Mass = 246.0672238(22)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 96
+Atomic Symbol = Cm
+Mass Number = 247
+Relative Atomic Mass = 247.0703541(47)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 96
+Atomic Symbol = Cm
+Mass Number = 248
+Relative Atomic Mass = 248.0723499(56)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 97
+Atomic Symbol = Bk
+Mass Number = 247
+Relative Atomic Mass = 247.0703073(59)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 97
+Atomic Symbol = Bk
+Mass Number = 249
+Relative Atomic Mass = 249.0749877(27)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 98
+Atomic Symbol = Cf
+Mass Number = 249
+Relative Atomic Mass = 249.0748539(23)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 98
+Atomic Symbol = Cf
+Mass Number = 250
+Relative Atomic Mass = 250.0764062(22)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 98
+Atomic Symbol = Cf
+Mass Number = 251
+Relative Atomic Mass = 251.0795886(48)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 98
+Atomic Symbol = Cf
+Mass Number = 252
+Relative Atomic Mass = 252.0816272(56)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 99
+Atomic Symbol = Es
+Mass Number = 252
+Relative Atomic Mass = 252.082980(54)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 100
+Atomic Symbol = Fm
+Mass Number = 257
+Relative Atomic Mass = 257.0951061(69)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 101
+Atomic Symbol = Md
+Mass Number = 258
+Relative Atomic Mass = 258.0984315(50)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 101
+Atomic Symbol = Md
+Mass Number = 260
+Relative Atomic Mass = 260.10365(34#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 102
+Atomic Symbol = No
+Mass Number = 259
+Relative Atomic Mass = 259.10103(11#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 103
+Atomic Symbol = Lr
+Mass Number = 262
+Relative Atomic Mass = 262.10961(22#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 104
+Atomic Symbol = Rf
+Mass Number = 267
+Relative Atomic Mass = 267.12179(62#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 105
+Atomic Symbol = Db
+Mass Number = 268
+Relative Atomic Mass = 268.12567(57#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 106
+Atomic Symbol = Sg
+Mass Number = 271
+Relative Atomic Mass = 271.13393(63#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 107
+Atomic Symbol = Bh
+Mass Number = 272
+Relative Atomic Mass = 272.13826(58#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 108
+Atomic Symbol = Hs
+Mass Number = 270
+Relative Atomic Mass = 270.13429(27#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 109
+Atomic Symbol = Mt
+Mass Number = 276
+Relative Atomic Mass = 276.15159(59#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 110
+Atomic Symbol = Ds
+Mass Number = 281
+Relative Atomic Mass = 281.16451(59#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 111
+Atomic Symbol = Rg
+Mass Number = 280
+Relative Atomic Mass = 280.16514(61#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 112
+Atomic Symbol = Cn
+Mass Number = 285
+Relative Atomic Mass = 285.17712(60#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 113
+Atomic Symbol = Nh
+Mass Number = 284
+Relative Atomic Mass = 284.17873(62#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 114
+Atomic Symbol = Fl
+Mass Number = 289
+Relative Atomic Mass = 289.19042(60#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 115
+Atomic Symbol = Mc
+Mass Number = 288
+Relative Atomic Mass = 288.19274(62#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 116
+Atomic Symbol = Lv
+Mass Number = 293
+Relative Atomic Mass = 293.20449(60#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 117
+Atomic Symbol = Ts
+Mass Number = 292
+Relative Atomic Mass = 292.20746(75#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =
+
+Atomic Number = 118
+Atomic Symbol = Og
+Mass Number = 294
+Relative Atomic Mass = 294.21392(71#)
+Isotopic Composition =
+Standard Atomic Weight =
+Notes =

--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
     - cython
     - specutils
     - tqdm
+    - weno4

--- a/lightweaver/__init__.py
+++ b/lightweaver/__init__.py
@@ -1,6 +1,6 @@
 from .atmosphere import Atmosphere, ScaleType, BoundaryCondition
 from .atomic_set import SpectrumConfiguration, RadiativeSet, lte_pops, hminus_pops
-from .atomic_table import atomic_weight_sort, AtomicTable, get_global_atomic_table, set_global_atomic_table
+from .atomic_table import PeriodicTable, AtomicAbundance, KuruczPfTable, DefaultAtomicAbundance
 from .constants import *
 from .molecule import MolecularTable
 from .multi import read_multi_atmos

--- a/lightweaver/atmosphere.py
+++ b/lightweaver/atmosphere.py
@@ -7,7 +7,7 @@ import lightweaver.constants as Const
 from scipy.interpolate import interp1d
 from numpy.polynomial.legendre import leggauss
 from .utils import ConvergenceError
-from .atomic_table import get_global_atomic_table
+from .atomic_table import PeriodicTable, AtomicAbundance, DefaultAtomicAbundance
 
 class ScaleType(Enum):
     Geometric = 0
@@ -24,7 +24,7 @@ def get_top_pressure(eos: witt, temp, ne=None, rho=None):
         return eos.pg_from_pe(temp, pe)
     elif rho is not None:
         return eos.pg_from_rho(temp, rho)
-    
+
     pgasCgs = np.array([0.70575286, 0.59018545, 0.51286639, 0.43719268, 0.37731009,
         0.33516886, 0.31342915, 0.30604891, 0.30059491, 0.29207645,
         0.2859011 , 0.28119224, 0.27893046, 0.27949676, 0.28299726,
@@ -42,7 +42,7 @@ def get_top_pressure(eos: witt, temp, ne=None, rho=None):
 
     ptop = np.interp(temp, tempCoord, pgasCgs)
     return ptop
-    
+
 @dataclass
 class Atmosphere:
     scale: ScaleType
@@ -63,16 +63,18 @@ class Atmosphere:
         if self.hydrogenPops is not None:
             self.nHTot = np.sum(self.hydrogenPops, axis=0)
 
-    def convert_scales(self, atomicTable=None, logG=2.44, Pgas=None, Pe=None, Ptop=None, PeTop=None):
+    def convert_scales(self, abundance: Optional[AtomicAbundance]=None, logG: float=2.44, Pgas: Optional[np.ndarray]=None,
+                       Pe: Optional[np.ndarray]=None, Ptop: Optional[float]=None, PeTop: Optional[float]=None):
         # TODO(cmo): Seriously, tidy up this function
-        if atomicTable is None:
-            atomicTable = get_global_atomic_table()
+        if abundance is None:
+            abundance = DefaultAtomicAbundance
 
-        if np.any(self.temperature < 2500):
-            raise ValueError('Extremely low temperature (< 2500 K)')
+        if np.any(self.temperature < 2000):
+            # NOTE(cmo): Minimum value was decreased in NICOLE so should be safe
+            raise ValueError('Extremely low temperature (< 2000 K)')
 
-        abundances = np.array([a[1] for a in atomicTable.abund.items()])
-        eos = witt(abund_init=abundances)
+        wittAbundances = np.array([abundance[e] for e in PeriodicTable.elements])
+        eos = witt(abund_init=wittAbundances)
 
         Nspace = self.Nspace
         if self.nHTot is None and self.ne is not None:
@@ -80,9 +82,9 @@ class Atmosphere:
             rho = np.zeros(Nspace)
             for k in range(Nspace):
                 rho[k] = eos.rho_from_pe(self.temperature[k], pe[k])
-            self.nHTot = np.copy(rho / (Const.CM_TO_M**3 / Const.G_TO_KG) / (Const.Amu * atomicTable.weightPerH))
+            self.nHTot = np.copy(rho / (Const.CM_TO_M**3 / Const.G_TO_KG) / (Const.Amu * abundance.massPerH))
         elif self.ne is None and self.nHTot is not None:
-            rho = Const.Amu * atomicTable.weightPerH * self.nHTot * Const.CM_TO_M**3 / Const.G_TO_KG
+            rho = Const.Amu * abundance.massPerH * self.nHTot * Const.CM_TO_M**3 / Const.G_TO_KG
             pe = np.zeros(Nspace)
             for k in range(Nspace):
                 pe[k] = eos.pe_from_rho(self.temperature[k], rho[k])
@@ -137,7 +139,7 @@ class Atmosphere:
                 pgas[0] = Ptop
                 pe[0] = PeTop
                 chi_c[0] = eos.contOpacity(self.temperature[0], pgas[0], pe[0], np.array([5000.0]))
-                avg_mol_weight = lambda k: atomicTable.weightPerH / (atomicTable.totalAbundance + pe[k] / pgas[k])
+                avg_mol_weight = lambda k: abundance.massPerH / (abundance.totalAbundance + pe[k] / pgas[k])
                 rho[0] = Ptop * avg_mol_weight(0) / Avog / eos.BK / self.temperature[0]
                 chi_c[0] /= rho[0]
 
@@ -168,16 +170,16 @@ class Atmosphere:
             # Filled in rho, pgas, and pe, based on EOS
             # Don't think rho is actually needed here
             # Need to fill in ne and nHTot -- based on RH method
-            self.ne = np.copy(pe / (eos.BK * self.temperature) / Const.CM_TO_M**3) 
+            self.ne = np.copy(pe / (eos.BK * self.temperature) / Const.CM_TO_M**3)
             turbPe = 0.5 * Const.MElectron * self.vturb**2
-            turbPg = 0.5 * atomicTable.avgMolWeight * Const.Amu * self.vturb**2
-            self.nHTot = ((pgas - pe) / (eos.BK * self.temperature) / Const.CM_TO_M**3 - self.ne * turbPe) / (atomicTable.totalAbundance * (1.0 + turbPg / (Const.KBoltzmann * self.temperature)))
+            turbPg = 0.5 * abundance.avgMass * Const.Amu * self.vturb**2
+            self.nHTot = ((pgas - pe) / (eos.BK * self.temperature) / Const.CM_TO_M**3 - self.ne * turbPe) / (abundance.totalAbundance * (1.0 + turbPg / (Const.KBoltzmann * self.temperature)))
             if np.any(self.ne < 0) or np.any(self.nHTot < 0):
                 raise ConvergenceError('Negative density (possibly produced by HSE iterations)')
 
 
-        rhoSI = Const.Amu * atomicTable.weightPerH * self.nHTot
-        rho = Const.Amu * atomicTable.weightPerH * self.nHTot * Const.CM_TO_M**3 / Const.G_TO_KG
+        rhoSI = Const.Amu * abundance.massPerH * self.nHTot
+        rho = Const.Amu * abundance.massPerH * self.nHTot * Const.CM_TO_M**3 / Const.G_TO_KG
         pgas = np.zeros_like(self.depthScale)
         pe = np.zeros_like(self.depthScale)
         for k in range(self.depthScale.shape[0]):
@@ -206,7 +208,7 @@ class Atmosphere:
             tau_ref = np.zeros(Nspace)
             height = self.depthScale
 
-            cmass[0] = (self.nHTot[0] * atomicTable.weightPerH + self.ne[0]) * (Const.KBoltzmann * self.temperature[0] / 10**logG)
+            cmass[0] = (self.nHTot[0] * abundance.massPerH + self.ne[0]) * (Const.KBoltzmann * self.temperature[0] / 10**logG)
             tau_ref[0] = 0.5 * chi_c[0] * (height[0] - height[1])
             if tau_ref[0] > 1.0:
                 tau_ref[0] = 0.0
@@ -245,7 +247,7 @@ class Atmosphere:
     def quadrature(self, Nrays: Optional[int]=None, mu: Optional[Sequence[float]]=None, wmu: Optional[Sequence[float]]=None):
 
         if Nrays is not None and mu is None:
-            if Nrays >= 1:        
+            if Nrays >= 1:
                 x, w = leggauss(Nrays)
                 mid, halfWidth = 0.5, 0.5
                 x = mid + halfWidth * x
@@ -295,8 +297,3 @@ class Atmosphere:
             raise AttributeError('Nrays not set, call atmos.rays or .quadrature first')
 
         return self.muz.shape[0]
-
-
-
-
-

--- a/lightweaver/atmosphere.py
+++ b/lightweaver/atmosphere.py
@@ -4,7 +4,6 @@ from typing import Sequence, TYPE_CHECKING, Optional, Union
 import numpy as np
 from .witt import witt
 import lightweaver.constants as Const
-from scipy.interpolate import interp1d
 from numpy.polynomial.legendre import leggauss
 from .utils import ConvergenceError
 from .atomic_table import PeriodicTable, AtomicAbundance, DefaultAtomicAbundance

--- a/lightweaver/atomic_model.py
+++ b/lightweaver/atomic_model.py
@@ -1,26 +1,29 @@
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from fractions import Fraction
-from typing import List, Sequence, Optional, Any, Iterator, cast
+from typing import List, Sequence, Optional, Any, Iterator, cast, TYPE_CHECKING
 import re
 
 import numpy as np
-from scipy.interpolate import interp1d
+from weno4 import weno4
 from parse import parse
 
 import lightweaver.constants as Const
-from .utils import gaunt_bf
-# from .atomic_table import AtomicTable, get_global_atomic_table
-from .atomic_table import PeriodicTable
+from .utils import gaunt_bf, sequence_repr
+from .atomic_table import PeriodicTable, Element
 from .barklem import Barklem
+from .zeeman import compute_zeeman_components, ZeemanComponents
 
-class VdwBarklemIncompatible(Exception):
-    pass
+if TYPE_CHECKING:
+    from .atmosphere import Atmosphere
+    from .atomic_set import SpeciesStateTable
+    from .collisional_rates import CollisionalRates
+    from .broadening import LineBroadening
 
 
 @dataclass
 class AtomicModel:
-    name: str
+    element: Element
     levels: Sequence['AtomicLevel']
     lines: Sequence['AtomicLine']
     continua: Sequence['AtomicContinuum']
@@ -34,11 +37,6 @@ class AtomicModel:
         for l in self.lines:
             l.setup(self)
 
-        # This is separate because all of the lines in
-        # an atom need to be initialised first
-        for l in self.lines:
-            l.setup_wavelength()
-
         for c in self.continua:
             c.setup(self)
 
@@ -46,7 +44,7 @@ class AtomicModel:
             c.setup(self)
 
     def __repr__(self):
-        s = 'AtomicModel(name="%s",\n\tlevels=[\n' % self.name
+        s = 'AtomicModel(element="%s",\n\tlevels=[\n' % repr(self.element)
         for l in self.levels:
             s += '\t\t' + repr(l) + ',\n'
         s += '\t],\n\tlines=[\n'
@@ -64,20 +62,28 @@ class AtomicModel:
     def __hash__(self):
         return hash(repr(self))
 
-    def vBroad(self, atmos):
-        vTherm = 2.0 * Const.KBoltzmann / (Const.Amu * PeriodicTable[self.atom].mass)
+    def vBroad(self, atmos: Atmosphere) -> np.ndarray:
+        vTherm = 2.0 * Const.KBoltzmann / (Const.Amu * PeriodicTable[self.element].mass)
         vBroad = np.sqrt(vTherm * atmos.temperature + atmos.vturb**2)
         return vBroad
+
+    @property
+    def transitions(self) -> Sequence['AtomicTransition']:
+        return self.lines + self.continua # type: ignore
 
 def reconfigure_atom(atom: AtomicModel):
     atom.__post_init__()
 
+def element_sort(atom: AtomicModel):
+    return atom.element
+
+# TODO(cmo): Tidy up comparisons
 def avoid_recursion_eq(a, b) -> bool:
     if isinstance(a, np.ndarray):
         if not np.all(a == b):
             return False
     elif isinstance(a, AtomicModel):
-        if a.name != b.name:
+        if a.element != b.element:
             return False
         if len(a.levels) != len(b.levels):
             return False
@@ -126,13 +132,21 @@ class AtomicLevel:
             if self.J <= self.L + self.S:
                 self.lsCoupling = True
 
+    def __hash__(self):
+        return hash((self.E, self.g, self.label, self.stage, self.J, self.L, self.S))
+
     def __eq__(self, other: object) -> bool:
-        return model_component_eq(self, other)
+        if isinstance(other, AtomicLevel):
+            return hash(self) == hash(other)
+        return False
 
     @property
     def lsCoupling(self) -> bool:
         if all(x is not None for x in (self.J, self.L, self.S)):
-            if self.J <= self.L + self.S:
+            J = cast(Fraction, self.J)
+            L = cast(int, self.L)
+            S = cast(Fraction, self.S)
+            if J <= L + S:
                 return True
         return False
 
@@ -162,144 +176,128 @@ class LineType(Enum):
 
 
 @dataclass
-class VdwApprox:
-    vals: Sequence[float]
-
-    def setup(self, line: 'AtomicLine', table: AtomicTable):
+class LineQuadrature:
+    def setup(self, line: 'AtomicLine'):
         pass
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, VdwApprox):
-            return False
+    def doppler_units(self, line: 'AtomicLine') -> np.ndarray:
+        raise NotImplementedError
 
-        return (self.vals == other.vals) and (type(self) is type(other))
+    def wavelength(self, line: 'AtomicLine', vMicroChar: float=Const.VMICRO_CHAR) -> np.ndarray:
+        raise NotImplementedError
 
-@dataclass(eq=False)
-class VdwUnsold(VdwApprox):
-    def setup(self, line: 'AtomicLine', table: AtomicTable):
-        self.line = line
-        if len(self.vals) != 2:
-            raise ValueError('VdwUnsold expects 2 coefficients (%s)' % repr(line))
+    def __repr__(self):
+        raise NotImplementedError
 
-        Z = line.jLevel.stage + 1
-        j = line.j
-        ic = j + 1
-        while line.atom.levels[ic].stage < Z:
-            ic += 1
-        cont = line.atom.levels[ic]
+    def __hash__(self):
+        raise NotImplementedError
 
-        deltaR = (Const.ERydberg / (cont.E_SI - line.jLevel.E_SI))**2 \
-                 - (Const.ERydberg / (cont.E_SI - line.iLevel.E_SI))**2
-        fourPiEps0 = 4.0 * np.pi * Const.Epsilon0
-        C625 = (2.5 * Const.QElectron**2 / fourPiEps0 * Const.ABarH / fourPiEps0 \
-                   * 2 * np.pi * (Z * Const.RBohr)**2 / Const.HPlanck * deltaR)**0.4
+@dataclass
+class LinearCoreExpWings(LineQuadrature):
+    """
+    RH-Style line quadrature.
+    """
+    qCore: float
+    qWing: float
+    Nlambda: int
+    beta: float = field(init=False)
 
-        name = line.atom.name
+    def __repr__(self):
+        s = '%s(qCore=%.4e, qWing=%.4e, Nlambda=%d)' % (type(self).__name__,
+             self.qCore, self.qWing, self.Nlambda)
+        return s
 
-        vRel35He = (8.0 * Const.KBoltzmann / (np.pi*Const.Amu * table[name].weight)\
-                    * (1.0 + table[name].weight / table['He'].weight))**0.3
-        vRel35H = (8.0 * Const.KBoltzmann / (np.pi*Const.Amu * table[name].weight)\
-                    * (1.0 + table[name].weight / table['H'].weight))**0.3
+    def __hash__(self):
+        return hash((self.qCore, self.qWing, self.Nlambda))
 
-        heAbund = table['He'].abundance
-        self.cross = 8.08 * (self.vals[0] * vRel35H \
-                             + self.vals[1] * heAbund * vRel35He) * C625
+    def setup(self, line: 'AtomicLine'):
+        if self.qWing <= 2.0 * self.qCore:
+            # Use linear scale to qWing
+            print("Ratio of qWing / (2*qCore) <= 1\n Using linear spacing for transition %d->%d" % (line.j, line.i))
+            self.beta = 1.0
+        else:
+            self.beta = self.qWing / (2.0 * self.qCore)
 
-    def broaden(self, temperature, nHGround, broad):
-        broad[:] = self.cross * temperature**0.3 * nHGround
+    def doppler_units(self, line: 'AtomicLine') -> np.ndarray:
+        Nlambda = self.Nlambda // 2 if self.Nlambda % 2 == 1 else (self.Nlambda - 1) // 2
+        Nlambda += 1
+        beta = self.beta
 
+        y = beta + np.sqrt(beta**2 + (beta - 1.0) * Nlambda + 2.0 - 3.0 * beta)
+        b = 2.0 * np.log(y) / (Nlambda - 1)
+        a = self.qWing / (Nlambda - 2.0 + y**2)
+        nl = np.arange(Nlambda)
+        q: np.ndarray = a * (nl + (np.exp(b * nl) - 1.0))
 
-@dataclass(eq=False)
-class VdwRidderRensbergen(VdwApprox):
-    # NOTE(cmo): RidderRensbergen actually uses all 4 VdW coeffs
-    def setup(self, line: 'AtomicLine', table: AtomicTable):
-        self.line = line
-        if len(self.vals) != 4:
-            raise ValueError('VdwRidderRensbergen expects 4 coefficients (%s)' % (repr(line)))
+        NlambdaFull = 2 * Nlambda - 1
+        result = np.zeros(NlambdaFull)
+        Nmid = Nlambda - 1
 
-        name = line.atom.name
-        self.gammaCorrH = 1e-8 * Const.CM_TO_M**3 \
-                        * (1.0 + table['H'].weight / table[name].weight)**self.vals[1]
-        self.gammaCorrHe = 1e-9 * Const.CM_TO_M**3 \
-                       * (1.0 + table['He'].weight / table[name].weight)**self.vals[3]
-        self.HeAbund = table['He'].abundance
+        result[:Nmid][::-1] = -q[1:]
+        result[Nmid+1:] = q[1:]
+        return result
 
-    def broaden(self, temperature, nHGround, broad):
-        broad[:] = self.gammaCorrH * self.vals[0] * temperature**self.vals[1] \
-                + self.gammaCorrHe * self.vals[2] * temperature**self.vals[3] \
-                    * self.HeAbund
-        broad *= nHGround
+    def wavelength(self, line: 'AtomicLine', vMicroChar=Const.VMICRO_CHAR) -> np.ndarray:
+        qToLambda = line.lambda0 * (vMicroChar / Const.CLight)
+        result = self.doppler_units(line)
+        result *= qToLambda
+        result += line.lambda0
+        return result
 
-@dataclass(eq=False)
-class VdwBarklem(VdwApprox):
-    # NOTE(cmo): Since Helium is treated as per Unsold, only 3 vals are used
-    def setup(self, line: 'AtomicLine', table: AtomicTable):
-        self.line = line
-        if len(self.vals) != 2:
-            raise ValueError('VdwBarklem expects 2 coefficients (%s)' % (repr(line)))
-        self.barklem = Barklem(table)
-        try:
-            newVals = self.barklem.get_active_cross_section(line.atom, line)
-        except:
-            raise VdwBarklemIncompatible
-
-        self.barklemVals = newVals
-
-        Z = line.jLevel.stage + 1
-        j = line.j
-        ic = j + 1
-        while line.atom.levels[ic].stage < Z:
-            ic += 1
-        cont = line.atom.levels[ic]
-
-        deltaR = (Const.ERydberg / (cont.E_SI - line.jLevel.E_SI))**2 \
-                 - (Const.ERydberg / (cont.E_SI - line.iLevel.E_SI))**2
-        fourPiEps0 = 4.0 * np.pi * Const.Epsilon0
-        C625 = (2.5 * Const.QElectron**2 / fourPiEps0 * Const.ABarH / fourPiEps0 \
-                   * 2 * np.pi * (Z * Const.RBohr)**2 / Const.HPlanck * deltaR)**0.4
-
-        name = line.atom.name
-
-        vRel35He = (8.0 * Const.KBoltzmann / (np.pi*Const.Amu * table[name].weight)\
-                    * (1.0 + table[name].weight / table['He'].weight))**0.3
-
-        heAbund = table['He'].abundance
-        self.cross = 8.08 * self.barklemVals[2] * heAbund * vRel35He * C625
-
-    def broaden(self, temperature, nHGround, broad):
-        broad[:] = self.barklemVals[0] * temperature**(0.5*(1.0-self.barklemVals[1])) \
-                    + self.cross * temperature**0.3
-        broad *= nHGround
 
 @dataclass
 class AtomicTransition:
-    def __eq__(self, other: object) -> bool:
-        return model_component_eq(self, other)
-    pass
-
-@dataclass(eq=False)
-class AtomicLine(AtomicTransition):
     j: int
     i: int
-    f: float
-    type: LineType
-    NlambdaGen: int
-    qCore: float
-    qWing: float
-    vdw: VdwApprox
-    gRad: float
-    stark: float
-    gLandeEff: Optional[float] = None
     atom: AtomicModel = field(init=False)
     jLevel: AtomicLevel = field(init=False)
     iLevel: AtomicLevel = field(init=False)
-    wavelength: np.ndarray = field(init=False)
-    preserveWavelength: bool = False
+
+    def setup(self, atom: AtomicModel):
+        raise NotImplementedError
+
+    def __hash__(self):
+        raise NotImplementedError
+
+    def __eq__(self, other: object) -> bool:
+        return model_component_eq(self, other)
+
+    def wavelength(self) -> np.ndarray:
+        raise NotImplementedError
+
+    @property
+    def lambda0(self) -> float:
+        raise NotImplementedError
+
+    @property
+    def lambda0_m(self) -> float:
+        raise NotImplementedError
+
+    @property
+    def transId(self) -> Tuple[Element, int, int]:
+        return (self.atom.element, self.i, self.j)
+
+
+@dataclass(eq=False)
+class AtomicLine(AtomicTransition):
+    f: float
+    type: LineType
+    quadrature: LineQuadrature
+    broadening: LineBroadening
+    gLandeEff: Optional[float] = None
+
+    def setup(self, atom: AtomicModel):
+        self.atom = atom
+        self.jLevel: AtomicLevel = self.atom.levels[self.j]
+        self.iLevel: AtomicLevel = self.atom.levels[self.i]
+        self.quadrature.setup(self)
+        self.broadening.setup(self)
 
     def __repr__(self):
-        s = 'AtomicLine(j=%d, i=%d, f=%e, type=%s, NlambdaGen=%d, qCore=%f, qWing=%f, vdw=%s, gRad=%e, stark=%e' % (
-                self.j, self.i, self.f, repr(self.type), self.NlambdaGen, self.qCore, self.qWing, repr(self.vdw),
-                self.gRad, self.stark)
+        s = '%s(j=%d, i=%d, f=%e, type=%s, quadrature=%s, broadening=%s' % (
+                type(self).__name__,
+                self.j, self.i, self.f, repr(self.type),
+                repr(self.quadrature), repr(self.broadening))
         if self.gLandeEff is not None:
             s += ', gLandeEff=%e' % self.gLandeEff
         s += ')'
@@ -308,234 +306,24 @@ class AtomicLine(AtomicTransition):
     def __hash__(self):
         return hash(repr(self))
 
-    @property
-    def Nlambda(self):
-        return self.wavelength.shape[0]
-
-def fraction_range(start: Fraction, stop: Fraction, step: Fraction=Fraction(1,1)) -> Iterator[Fraction]:
-    while start < stop:
-        yield start
-        start += step
-
-@dataclass
-class ZeemanComponents:
-    alpha: np.ndarray
-    strength: np.ndarray
-    shift: np.ndarray
-
-@dataclass(eq=False)
-class VoigtLine(AtomicLine):
-    def setup(self, atom):
-        if self.j < self.i:
-            self.i, self.j = self.j, self.i
-
-        self.atom: AtomicModel = atom
-        self.jLevel: AtomicLevel = self.atom.levels[self.j]
-        self.iLevel: AtomicLevel = self.atom.levels[self.i]
-
-        try:
-            self.vdw.setup(self, atom.atomicTable)
-        except VdwBarklemIncompatible:
-            print("Unable to treat line %d->%d of atom %s with Barklem broadening, using Unsold." % (self.j, self.i, self.atom.name))
-            vals = self.vdw.vals
-            self.vdw = VdwUnsold(vals)
-            self.vdw.setup(self, atom.atomicTable)
-
-    def __repr__(self):
-        s = 'VoigtLine(j=%d, i=%d, f=%e, type=%s, NlambdaGen=%d, qCore=%f, qWing=%f, vdw=%s, gRad=%e, stark=%e' % (
-                self.j, self.i, self.f, repr(self.type), self.NlambdaGen, self.qCore, self.qWing, repr(self.vdw),
-                self.gRad, self.stark)
-        if self.gLandeEff is not None:
-            s += ', gLandeEff=%e' % self.gLandeEff
-        s += ')'
-        return s
-
-    def linear_stark_broaden(self, atmos):
-        # We don't need to read n from the label, we can use the fact that for H -- which is the only atom we have here, g=2n^2
-        nUpper = int(np.round(np.sqrt(0.5*self.jLevel.g)))
-        nLower = int(np.round(np.sqrt(0.5*self.iLevel.g)))
-
-        a1 = 0.642 if nUpper - nLower == 1 else 1.0
-        C = a1 * 0.6 * (nUpper**2 - nLower**2) * Const.CM_TO_M**2
-        GStark = C * atmos.ne**(2.0/3.0)
-        return GStark
-
-    def stark_broaden(self, atmos):
-        if self.stark > 0.0:
-            weight = self.atom.atomicTable[self.atom.name].weight
-            C = 8.0 * Const.KBoltzmann / (np.pi * Const.Amu * weight)
-            Cm = (1.0 + weight / (Const.MElectron / Const.Amu))**(1.0/6.0)
-            # NOTE(cmo): 28.0 is average atomic weight
-            Cm += (1.0 + weight / (28.0))**(1.0/6.0)
-
-            Z = self.iLevel.stage + 1
-            ic = self.i + 1
-            while self.atom.levels[ic].stage < Z and ic < len(self.atom.levels):
-                ic += 1
-            if self.atom.levels[ic].stage == self.iLevel.stage:
-                raise ValueError('Cant find overlying cont: %s' % repr(self))
-
-            E_Ryd = Const.ERydberg / (1.0 + Const.MElectron / (weight * Const.Amu))
-            neff_l = Z * np.sqrt(E_Ryd / (self.atom.levels[ic].E_SI - self.iLevel.E_SI))
-            neff_u = Z * np.sqrt(E_Ryd / (self.atom.levels[ic].E_SI - self.jLevel.E_SI))
-
-            C4 = Const.QElectron**2 / (4.0 * np.pi * Const.Epsilon0) \
-                * Const.RBohr \
-                * (2.0 * np.pi * Const.RBohr**2 / Const.HPlanck) / (18.0 * Z**4) \
-                * ((neff_u * (5.0 * neff_u**2 + 1.0))**2 \
-                    - (neff_l * (5.0 * neff_l**2 + 1.0))**2)
-            cStark23 = 11.37 * (self.stark * C4)**(2.0/3.0)
-
-            vRel = (C * atmos.temperature)**(1.0/6.0) * Cm
-            stark = cStark23 * vRel * atmos.ne
-        elif self.stark < 0.0:
-            stark = np.abs(self.stark) * atmos.ne
-        else:
-            stark = np.zeros(atmos.Nspace)
-
-        if self.atom.name.upper().strip() == 'H':
-            stark += self.linear_stark_broaden(atmos)
-        return stark
-
-    def setup_wavelength(self):
-        # self.xrd = []
-
-        # # This is just a hack to keep the search happy
-        # self.wavelength = np.zeros(1)
-        # # NOTE(cmo): This is currently disabled -- we're not gonna do XRD anyway
-        # if self.type == LineType.PRD and False:
-
-        #     thisIdx = self.atom.lines.index(self)
-
-        #     for i, l in enumerate(self.atom.lines):
-        #         if l.type == LineType.PRD and l.j == self.j and l.i != self.i:
-        #             self.xrd.append(l)
-
-        #             if i > thisIdx:
-        #                 waveratio = self.xrd[-1].lambda0 / self.lambda0
-        #                 self.xrd[-1].qWing = waveratio * self.qWing
-
-        #     if len(self.xrd) > 0:
-        #         print("Found %d subordinate PRD lines, for line %d->%d of atom %s" % \
-        #             (len(self.xrd), self.j, self.i, self.atom.name))
-
-        if self.preserveWavelength:
-            print('preserveWavelength set on %s, ignoring NlambdaGen' % (repr(self)))
-            return
-
-        # Compute default lambda grid
-        Nlambda = self.NlambdaGen // 2 if self.NlambdaGen % 2 == 1 else (self.NlambdaGen - 1) // 2
-        Nlambda += 1
-        # Nlambda = self.Nlambda // 2 if self.Nlambda % 2 == 1 else (self.Nlambda + 1) // 2
-
-        if self.qWing <= 2.0 * self.qCore:
-            # Use linear scale to qWing
-            print("Ratio of qWing / (2*qCore) <= 1\n Using linear spacing for transition %d->%d" % (self.j, self.i))
-            beta = 1.0
-        else:
-            beta = self.qWing / (2.0 * self.qCore)
-
-        y = beta + np.sqrt(beta**2 + (beta - 1.0) * Nlambda + 2.0 - 3.0 * beta)
-        b = 2.0 * np.log(y) / (Nlambda - 1)
-        a = self.qWing / (Nlambda - 2.0 + y**2)
-        self.a = a
-        self.b = b
-        self.y = y
-        nl = np.arange(Nlambda)
-        self.q: np.ndarray = a * (nl + (np.exp(b * nl) - 1.0))
-
-        qToLambda = self.lambda0 * (Const.VMICRO_CHAR / Const.CLight)
-        NlambdaFull = 2 * Nlambda - 1
-        line = np.zeros(NlambdaFull)
-        Nmid = Nlambda - 1
-
-        line[Nmid] = self.lambda0
-        line[:Nmid][::-1] = self.lambda0 - qToLambda * self.q[1:]
-        line[Nmid+1:] = self.lambda0 + qToLambda * self.q[1:]
-        self.wavelength = line
+    def wavelength(self, vMicroChar=Const.VMICRO_CHAR) -> np.ndarray:
+        return self.quadrature.wavelength(self, vMicroChar=vMicroChar)
 
     def zeeman_components(self) -> Optional[ZeemanComponents]:
-        # Just do basic anomalous Zeeman splitting
-        if self.gLandeEff is not None:
-            alpha = np.array([-1, 0, 1], dtype=np.int32)
-            strength = np.ones(3)
-            shift = alpha * self.gLandeEff
-            return ZeemanComponents(alpha, strength, shift)
+        return compute_zeeman_components(self)
 
-        # Do LS coupling
-        if self.iLevel.lsCoupling and self.jLevel.lsCoupling:
-            # Mypy... you're a pain sometimes... (even if you are technically correct)
-            Jl = cast(Fraction, self.iLevel.J)
-            Ll = cast(int, self.iLevel.L)
-            Sl = cast(Fraction, self.iLevel.S)
-            Ju = cast(Fraction, self.jLevel.J)
-            Lu = cast(int, self.jLevel.L)
-            Su = cast(Fraction, self.jLevel.S)
-
-            gLl = lande_factor(Jl, Ll, Sl)
-            gLu = lande_factor(Ju, Lu, Su)
-            alpha = []
-            strength = []
-            shift = []
-            norm = np.zeros(3)
-
-            for ml in fraction_range(-Jl, Jl+1):
-                for mu in fraction_range(-Ju, Ju+1):
-                    if abs(ml - mu) <= 1.0:
-                        alpha.append(int(ml - mu))
-                        shift.append(gLl*ml - gLu*mu)
-                        strength.append(zeeman_strength(Ju, mu, Jl, ml))
-                        norm[alpha[-1]+1] += strength[-1]
-            alpha = np.array(alpha, dtype=np.int32)
-            strength = np.array(strength)
-            shift = np.array(shift)
-            strength /= norm[alpha + 1]
-
-            return ZeemanComponents(alpha, strength, shift)
-
-        return None
-
-
-
-    def polarised_wavelength(self, bChar: Optional[float]=None) -> Sequence[float]:
-        ## NOTE(cmo): bChar in TESLA
-        if any([not self.iLevel.lsCoupling, not self.jLevel.lsCoupling]) or \
-           (self.gLandeEff is None):
-            print("Can't treat line %d->%d with polarization" % (self.j, self.i))
-            return self.wavelength
-
-        if bChar is None:
-            bChar = Const.B_CHAR
-        # /* --- When magnetic field is present account for denser
-        #        wavelength spacing in the unshifted \pi component, and the
-        #        red and blue-shifted circularly polarized components.
-        #        First, get characteristic Zeeman splitting -- ------------ */
-        gLandeEff = effective_lande(self)
-        qBChar = gLandeEff * (Const.QElectron / (4.0 * np.pi * Const.MElectron)) * \
-                  (self.lambda0_m) * bChar / Const.VMICRO_CHAR
-
-        if 0.5 * qBChar >= self.qCore:
-            print("Characteristic Zeeman splitting qBChar (=%f) >= 2*qCore for transition %d->%d" % (qBChar, self.j, self.i))
-
-        Nlambda = self.q.shape[0]
-        NB = np.searchsorted(self.q, 0.5 * qBChar)
-        qBShift = 2 * self.q[NB]
-        qB = np.zeros(self.q.shape[0] + 2 * NB)
-        qB[:Nlambda] = self.q
-
-        nl = np.arange(NB+1, 2*NB+1)
-        qB[NB+1:2*NB+1] = qBShift - self.a * (2*NB - nl + \
-                                        (np.exp(self.b * (2 * NB - nl)) -1.0))
-        nl = np.arange(2*NB+1, Nlambda+2*NB)
-        qB[2*NB+1:] = qBShift + self.a * (nl - 2*NB  + \
-                                     (np.exp(self.b * (nl - 2 * NB)) - 1.0))
-        line = np.zeros(2 * qB.shape[0] - 1)
-        Nmid = qB.shape[0] - 1
-        qToLambda = self.lambda0 * (Const.VMICRO_CHAR / Const.CLight)
-        line[Nmid] = self.lambda0
-        line[:Nmid][::-1] = self.lambda0 - qToLambda * qB[1:]
-        line[Nmid+1:] = self.lambda0 + qToLambda * qB[1:]
-        return line
+    @property
+    def overlyingContinuumLevel(self) -> AtomicLevel:
+        Z = self.jLevel.stage + 1
+        j = self.j
+        ic = j + 1
+        try:
+            while self.atom.levels[ic].stage < Z:
+                ic += 1
+            cont = self.atom.levels[ic]
+            return cont
+        except:
+            raise ValueError('No overlying continuum level found for line %s' % repr(self))
 
     @property
     def lambda0(self) -> float:
@@ -565,90 +353,41 @@ class VoigtLine(AtomicLine):
     def polarisable(self) -> bool:
         return (self.iLevel.lsCoupling and self.jLevel.lsCoupling) or (self.gLandeEff is not None)
 
-    def damping(self, atmos, vBroad, hGround):
-        aDamp = np.zeros(atmos.Nspace)
-        Qelast = np.zeros(atmos.Nspace)
 
-        self.vdw.broaden(atmos.temperature, hGround, aDamp)
-        Qelast += aDamp
+@dataclass(eq=False)
+class VoigtLine(AtomicLine):
 
-        Qelast += self.stark_broaden(atmos)
+    # TODO(cmo): Provide old interface for now to avoid needing to change all of this right now?
+    def damping(self, atmos: Atmosphere, eqPops: SpeciesStateTable):
+        Qs = self.damping(atmos, eqPops)
 
+        vBroad = self.atom.vBroad(atmos)
         cDop = self.lambda0_m / (4.0 * np.pi)
-        aDamp = (self.gRad + Qelast) * cDop / vBroad
-        return aDamp, Qelast
-
-def zeeman_strength(Ju: Fraction, Mu: Fraction, Jl: Fraction, Ml: Fraction) -> float:
-    alpha  = int(Ml - Mu)
-    dJ = int(Ju - Jl)
-
-    # These parameters are x2 those in del Toro Iniesta (p. 137), but we normalise after the fact, so it's fine
-
-    if dJ == 0: # jMin = ju = jl
-        if alpha == 0: # pi trainsitions
-            s = 2.0 * Mu**2
-        elif alpha == -1: # sigma_b transitions
-            s = (Ju + Mu) * (Ju - Mu + 1.0)
-        elif alpha == 1: # sigma_r transitions
-            s = (Ju - Mu) * (Ju + Mu + 1.0)
-    elif dJ == 1: # jMin = jl, Mi = Ml
-        if alpha == 0: # pi trainsitions
-            s = 2.0 * ((Jl + 1)**2 - Ml**2)
-        elif alpha == -1: # sigma_b transitions
-            s = (Jl + Ml + 1) * (Jl + Ml + 2.0)
-        elif alpha == 1: # sigma_r transitions
-            s = (Jl - Ml + 1.0) * (Jl - Ml + 2.0)
-    elif dJ == -1: # jMin = ju, Mi = Mu
-        if alpha == 0: # pi trainsitions
-            s = 2.0 * ((Ju + 1)**2 - Mu**2)
-        elif alpha == -1: # sigma_b transitions
-            s = (Ju - Mu + 1) * (Ju - Mu + 2.0)
-        elif alpha == 1: # sigma_r transitions
-            s = (Ju + Mu + 1.0) * (Ju + Mu + 2.0)
-    else:
-        raise ValueError('Invalid dJ: %d' % dJ)
-
-    return float(s)
-
-def lande_factor(J: Fraction, L: int, S: Fraction) -> float:
-    if J == 0.0:
-        return 0.0
-    return float(1.5 + (S * (S + 1.0) - L * (L + 1)) / (2.0 * J * (J + 1.0)))
-
-def effective_lande(line: AtomicLine):
-    if line.gLandeEff is not None:
-        return line.gLandeEff
-
-    i = line.iLevel
-    j = line.jLevel
-    if any(x is None for x in [i.J, i.L, i.S, j.J, j.L, j.S]):
-        raise ValueError('Cannot compute gLandeEff as gLandeEff not set and some of J, L and S None for line %s'%repr(line))
-    gL = lande_factor(i.J, i.L, i.S) # type: ignore
-    gU = lande_factor(j.J, j.L, j.S) # type: ignore
-
-    return 0.5 * (gU + gL) + \
-           0.25 * (gU - gL) * (j.J * (j.J + 1.0) - i.J * (i.J + 1.0)) # type: ignore
-
+        aDamp = (Qs.Qinelast + Qs.Qelast) * cDop / vBroad
+        return aDamp, Qs.Qelast
 
 @dataclass(eq=False)
 class AtomicContinuum(AtomicTransition):
-    j: int
-    i: int
-    atom: AtomicModel = field(init=False)
-    jLevel: AtomicLevel = field(init=False)
-    iLevel: AtomicLevel = field(init=False)
-    wavelength: np.ndarray = field(init=False)
-    alpha: np.ndarray = field(init=False)
+
+    def setup(self, atom: AtomicModel):
+        pass
 
     def __repr__(self):
         s = 'AtomicContinuum(j=%d, i=%d)' % (self.j, self.i)
         return s
 
-    def compute_alpha(self, wavelength) -> np.ndarray:
-        pass
-
     def __hash__(self):
         return hash(repr(self))
+
+    def alpha(self, wavelength: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def wavelength(self) -> np.ndarray:
+        raise NotImplementedError
+
+    @property
+    def minLambda(self) -> float:
+        raise NotImplementedError
 
     @property
     def lambda0(self) -> float:
@@ -665,56 +404,49 @@ class AtomicContinuum(AtomicTransition):
 
 @dataclass(eq=False)
 class ExplicitContinuum(AtomicContinuum):
-    alphaGrid: Sequence[Sequence[float]]
+    wavelengthGrid: Sequence[float]
+    alphaGrid: Sequence[float]
 
-    def setup(self, atom):
+    def setup(self, atom: AtomicModel):
         if self.j < self.i:
             self.i, self.j = self.j, self.i
         self.atom = atom
-        lambdaAlpha = np.array(self.alphaGrid).T
-        self.wavelength = np.copy(lambdaAlpha[0, ::-1])
+        self.wavelengthGrid = np.asarray(self.wavelengthGrid)
         if not np.all(np.diff(self.wavelength) > 0.0):
             raise ValueError('Wavelength array not monotonically increasing in continuum %s' % repr(self))
-        self.alpha = np.copy(lambdaAlpha[1, ::-1])
-        self.jLevel: AtomicLevel = atom.levels[self.j]
-        self.iLevel: AtomicLevel = atom.levels[self.i]
-        if self.lambdaEdge > self.wavelength[-1]:
-            wav = np.concatenate((self.wavelength, np.array([self.lambdaEdge])))
-            self.wavelength = wav
-            self.alpha = np.concatenate((self.alpha, np.array([self.alpha[-1]])))
+        self.alphaGrid = np.asarray(self.alphaGrid)
+        self.jLevel = atom.levels[self.j]
+        self.iLevel = atom.levels[self.i]
+        if self.lambdaEdge > self.wavelengthGrid[-1]:
+            wav = np.concatenate((self.wavelengthGrid, np.array([self.lambdaEdge])))
+            self.wavelengthGrid = wav
+            self.alphaGrid = np.concatenate((self.alphaGrid, np.array([self.alphaGrid[-1]])))
 
     def __repr__(self):
-        s = 'ExplicitContinuum(j=%d, i=%d, alphaGrid=%s)' % (self.j, self.i, repr(self.alphaGrid))
+        s = 'ExplicitContinuum(j=%d, i=%d, wavelengthGrid=%s, alphaGrid=%s)' % (self.j, self.i,
+        sequence_repr(self.wavelengthGrid), sequence_repr(self.alphaGrid))
         return s
 
-    def compute_alpha(self, wavelength) -> np.ndarray:
-        alpha = interp1d(self.wavelength, self.alpha, kind=3, bounds_error=False, fill_value=0.0)(wavelength)
+    def alpha(self, wavelength: np.ndarray) -> np.ndarray:
+        alpha = weno4(wavelength, self.wavelengthGrid, self.alphaGrid, left=0.0, right=0.0)
         alpha[wavelength < self.minLambda] = 0.0
         alpha[wavelength > self.lambdaEdge] = 0.0
-        if np.any(alpha < 0.0):
-            alpha = interp1d(self.wavelength, self.alpha, bounds_error=False, fill_value=0.0)(wavelength)
+        alpha[alpha < 0.0] = 0.0
         return alpha
 
-    @property
-    def Nlambda(self) -> int:
-        return self.wavelength.shape[0]
-
-    @property
-    def lambda0(self) -> float:
-        return self.lambda0_m / Const.NM_TO_M
-
-    @property
-    def lambdaEdge(self) -> float:
-        return self.lambda0
+    def wavelength(self) -> np.ndarray:
+        grid = cast(np.ndarray, self.wavelengthGrid)
+        edge = self.lambdaEdge
+        result = np.copy(grid[(grid >= self.minLambda) & (grid <= edge)])
+        # NOTE(cmo): If the last value before the edge is more than 0.1 nm away
+        # then put the edge in.
+        if edge - grid[-1] > 0.1:
+            result = np.concatenate((result, (edge,)))
+        return result
 
     @property
     def minLambda(self) -> float:
-        return self.wavelength[0]
-
-    @property
-    def lambda0_m(self) -> float:
-        deltaE = self.jLevel.E_SI - self.iLevel.E_SI
-        return Const.HC / deltaE
+        return self.wavelengthGrid[0]
 
 @dataclass(eq=False)
 class HydrogenicContinuum(AtomicContinuum):
@@ -734,12 +466,8 @@ class HydrogenicContinuum(AtomicContinuum):
         self.iLevel: AtomicLevel = atom.levels[self.i]
         if self.minLambda >= self.lambda0:
             raise ValueError('Minimum wavelength is larger than continuum edge at %f [nm] in continuum %s' % (self.lambda0, repr(self)))
-        self.wavelength = np.linspace(self.minLambda, self.lambdaEdge, self.NlambdaGen)
-        self.alpha = self.compute_alpha(self.wavelength)
 
-    def compute_alpha(self, wavelength) -> np.ndarray:
-        # if self.atom.name.strip() != 'H':
-        # NOTE(cmo): As it should be, the general case is equivalent for H
+    def alpha(self, wavelength: np.ndarray) -> np.ndarray:
         Z = self.jLevel.stage
         nEff = Z * np.sqrt(Const.ERydberg / (self.jLevel.E_SI - self.iLevel.E_SI))
         gbf0 = gaunt_bf(self.lambda0, nEff, Z)
@@ -748,56 +476,6 @@ class HydrogenicContinuum(AtomicContinuum):
         alpha[wavelength < self.minLambda] = 0.0
         alpha[wavelength > self.lambdaEdge] = 0.0
         return alpha
-        # else:
-        #     sigma0 = 32.0 / (3.0 * np.sqrt(3.0)) * Const.Q_ELECTRON**2 / (4.0 * np.pi * Const.EPSILON_0) / (Const.M_ELECTRON * Const.CLIGHT) * Const.HPLANCK / (2.0 * Const.E_RYDBERG)
-        #     nEff = np.sqrt(Const.E_RYDBERG / (self.jLevel.E_SI - self.iLevel.E_SI))
-        #     gbf = gaunt_bf(wavelength, nEff, self.iLevel.stage+1)
-        #     sigma = sigma0 * nEff * gbf * (wavelength / self.lambdaEdge)**3
-        #     sigma[wavelength < self.minLambda] = 0.0
-        #     sigma[wavelength > self.lambdaEdge] = 0.0
-        #     return sigma
 
-    @property
-    def lambda0(self) -> float:
-        return self.lambda0_m / Const.NM_TO_M
-
-    @property
-    def lambdaEdge(self) -> float:
-        return self.lambda0
-
-    @property
-    def lambda0_m(self) -> float:
-        deltaE = self.jLevel.E_SI - self.iLevel.E_SI
-        return Const.HC / deltaE
-
-    @property
-    def Nlambda(self) -> int:
-        return self.wavelength.shape[0]
-
-@dataclass
-class CollisionalRates:
-    j: int
-    i: int
-    atom: AtomicModel = field(init=False)
-
-    def __repr__(self):
-        s = 'CollisionalRates(j=%d, i=%d, temperature=%s, rates=%s)' % (self.j, self.i, repr(self.temperature), repr(self.rates))
-        return s
-
-    def setup(self, atom):
-        pass
-
-    def compute_rates(self, atmos, nstar, Cmat):
-        pass
-
-    def __eq__(self, other: object) -> bool:
-        return model_component_eq(self, other)
-
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        try:
-            del state['interpolator']
-        except KeyError:
-            pass
-
-        return state
+    def wavelength(self) -> np.ndarray:
+        return np.linspace(self.minLambda, self.lambdaEdge, self.NlambdaGen)

--- a/lightweaver/atomic_set.py
+++ b/lightweaver/atomic_set.py
@@ -1,111 +1,18 @@
 from dataclasses import dataclass, field
-from .atomic_table import atomic_weight_sort, Element, AtomicTable, get_global_atomic_table
-from .atomic_model import AtomicLine, AtomicModel, AtomicContinuum
+from .atomic_table import PeriodicTable, Element, Isotope, AtomicAbundance, DefaultAtomicAbundance, KuruczPf, KuruczPfTable
+from .atomic_model import AtomicTransition, AtomicLine, AtomicModel, AtomicContinuum, element_sort
 from .atmosphere import Atmosphere
 from .molecule import Molecule, MolecularTable
 import lightweaver.constants as Const
-from typing import List, Sequence, Set, Optional, Any, Union, Dict
+from typing import List, Sequence, Set, Optional, Any, Union, Dict, Tuple, Iterable
 from copy import copy, deepcopy
 from collections import OrderedDict
 import numpy as np
 from scipy.linalg import solve
 from scipy.optimize import newton_krylov
 
-@dataclass
-class SpectrumConfiguration:
-    radSet: 'RadiativeSet'
-    wavelength: np.ndarray
-    transitions: List[Union[AtomicLine, AtomicContinuum]]
-    models: List[AtomicModel]
-    blueIdx: List[int]
-    activeSet: List[List[Union[AtomicLine, AtomicContinuum]]]
-
-    def subset_configuration(self, wavelengths, expandLineGridsNm=0.0) -> 'SpectrumConfiguration':
-        Nblue = np.searchsorted(self.wavelength, wavelengths[0])
-        Nred = min(np.searchsorted(self.wavelength, wavelengths[-1])+1, self.wavelength.shape[0]-1)
-
-        trans: List[Union[AtomicLine, AtomicContinuum]] = []
-        continuaPerAtom: Dict[str, List[List[AtomicContinuum]]] = {}
-        linesPerAtom: Dict[str, List[List[AtomicLine]]]= {}
-        upperLevels: Dict[str, List[Set[int]]] = {}
-        lowerLevels: Dict[str, List[Set[int]]] = {}
-
-        radSet = self.radSet
-        models = [m for m in (radSet.activeSet | radSet.detailedStaticSet)]
-        for atom in self.models:
-            for l in atom.lines:
-                if l.wavelength[-1] < wavelengths[0]:
-                    continue
-                if l.wavelength[0] > wavelengths[-1]:
-                    continue
-                trans.append(l)
-                if expandLineGridsNm != 0.0:
-                    l.wavelength = np.concatenate([[l.wavelength[0]-expandLineGridsNm, l.wavelength, l.wavelength[-1]+expandLineGridsNm]])
-            for c in atom.continua:
-                if c.wavelength[-1] < wavelengths[0]:
-                    continue
-                if c.wavelength[0] > wavelengths[-1]:
-                    continue
-                trans.append(c)
-        activeAtoms = [t.atom for t in trans]
-
-        for atom in activeAtoms:
-            continuaPerAtom[atom.name] = []
-            linesPerAtom[atom.name] = []
-            upperLevels[atom.name] = []
-            lowerLevels[atom.name] = []
-
-        blueIdx = []
-        redIdx = []
-        for t in trans:
-            blueIdx.append(np.searchsorted(wavelengths, t.wavelength[0]))
-            redIdx.append(min(np.searchsorted(wavelengths, t.wavelength[-1])+1, wavelengths.shape[-1]))
-
-        for i, t in enumerate(trans):
-            if isinstance(t, AtomicContinuum):
-                while wavelengths[redIdx[i]-1] > t.lambdaEdge and redIdx[i] > 0:
-                    redIdx[i] -= 1
-            wavelength = np.copy(wavelengths[blueIdx[i]:redIdx[i]])
-            if isinstance(t, AtomicContinuum):
-                t.alpha = t.compute_alpha(wavelength)
-            t.wavelength = wavelength
-
-        activeSet: List[List[Union[AtomicLine, AtomicContinuum]]] = []
-        activeLines: List[List[AtomicLine]] = []
-        activeContinua: List[List[AtomicContinuum]] = []
-        contributors: List[List[AtomicModel]] = []
-        for i in range(wavelengths.shape[0]):
-            activeSet.append([])
-            activeLines.append([])
-            activeContinua.append([])
-            contributors.append([])
-            for atom in activeAtoms:
-                continuaPerAtom[atom.name].append([])
-                linesPerAtom[atom.name].append([])
-                upperLevels[atom.name].append(set())
-                lowerLevels[atom.name].append(set())
-            for kr, t in enumerate(trans):
-                if blueIdx[kr] <= i < redIdx[kr]:
-                    activeSet[-1].append(t)
-                    contributors[-1].append(t.atom)
-                    if isinstance(t, AtomicContinuum):
-                        activeContinua[-1].append(t)
-                        continuaPerAtom[t.atom.name][-1].append(t)
-                        upperLevels[t.atom.name][-1].add(t.j)
-                        lowerLevels[t.atom.name][-1].add(t.i)
-                    elif isinstance(t, AtomicLine):
-                        activeLines[-1].append(t)
-                        linesPerAtom[t.atom.name][-1].append(t)
-                        upperLevels[t.atom.name][-1].add(t.j)
-                        lowerLevels[t.atom.name][-1].add(t.i)
-
-
-        return SpectrumConfiguration(radSet=radSet, wavelength=wavelengths, transitions=trans,
-                                     models=activeAtoms, blueIdx=blueIdx, activeSet=activeSet)
-
-
-
-def lte_pops(atomicModel, temperature, ne, nTotal, debye=True):
+def lte_pops(atomicModel: AtomicModel, temperature: np.ndarray,
+             ne: np.ndarray, nTotal: np.ndarray, debye: bool=True) -> np.ndarray:
     Nlevel = len(atomicModel.levels)
     Nspace = ne.shape[0]
     c1 = (Const.HPlanck / (2.0 * np.pi * Const.MElectron)) * (Const.HPlanck / Const.KBoltzmann)
@@ -150,25 +57,35 @@ def lte_pops(atomicModel, temperature, ne, nTotal, debye=True):
 
 
 class LteNeIterator:
-    def __init__(self, atoms, temperature, nHTot):
-        sortedAtoms = sorted(atoms, key=atomic_weight_sort)
-        self.nTotal = [a.atomicTable[a.name].abundance * nHTot 
+    def __init__(self, atoms: Iterable[AtomicModel], temperature: np.ndarray,
+                 nHTot: np.ndarray, abundance: AtomicAbundance,
+                 nlteStartingPops: Dict[Element, np.ndarray]):
+        sortedAtoms = sorted(atoms, key=element_sort)
+        self.nTotal = [abundance[a.element] * nHTot
                        for a in sortedAtoms]
         self.stages = [np.array([l.stage for l in a.levels])
                        for a in sortedAtoms]
         self.temperature = temperature
         self.nHTot = nHTot
         self.sortedAtoms = sortedAtoms
+        self.abundances = [abundance[a.element] for a in sortedAtoms]
+        self.nlteStartingPops = nlteStartingPops
 
-    def __call__(self, prevNeRatio):
+    def __call__(self, prevNeRatio: np.ndarray) -> np.ndarray:
         atomicPops = []
         ne = np.zeros_like(prevNeRatio)
         prevNe = prevNeRatio * self.nHTot
 
         for i, a in enumerate(self.sortedAtoms):
-            nStar = lte_pops(a, self.temperature, prevNe, 
+            nStar = lte_pops(a, self.temperature, prevNe,
                              self.nTotal[i], debye=True)
-            atomicPops.append(AtomicState(a, nStar, self.nTotal[i]))
+            atomicPops.append(AtomicState(a, nStar, self.nTotal[i], abundance=self.abundances[i]))
+            # NOTE(cmo): Take into account NLTE pops if provided
+            if a.element in self.nlteStartingPops:
+                if self.nlteStartingPops[a.element].shape != nStar:
+                    raise ValueError('Starting populations provided for %s do not match model.' % e)
+                nStar = self.nlteStartingPops[a.element]
+
             ne += np.sum(nStar * self.stages[i][:, None], axis=0)
 
         self.atomicPops = atomicPops
@@ -176,41 +93,38 @@ class LteNeIterator:
         return diff
 
 
-class AtomicStateTable:
-    def __init__(self, atoms: List['AtomicState']):
-        self.atoms = atoms
-        self.indices = OrderedDict(zip([a.model.name.upper().ljust(2) for a in atoms], list(range(len(atoms)))))
+@dataclass
+class SpectrumConfiguration:
+    radSet: 'RadiativeSet'
+    wavelength: np.ndarray
+    models: List[AtomicModel]
+    transWavelengths: Dict[Tuple[Element, int, int], np.ndarray]
+    blueIdx: Dict[Tuple[Element, int, int], int]
+    activeTrans: Dict[Tuple[Element, int, int], bool]
+    activeWavelengths: Dict[Tuple[Element, int, int], np.ndarray]
 
-    def __contains__(self, name: str) -> bool:
-        name = name.upper().ljust(2)
-        return name in self.indices.keys()
+    def subset_configuration(self, wavelengths) -> 'SpectrumConfiguration':
+        Nblue = np.searchsorted(self.wavelength, wavelengths[0])
+        Nred = min(np.searchsorted(self.wavelength, wavelengths[-1])+1, self.wavelength.shape[0])
 
-    def __len__(self) -> int:
-        return len(self.atoms)
+        activeTrans = {k: np.any(v[Nblue:Nred]) for k, v in self.activeWavelengths.items()}
+        transGrids = {k: np.copy(wavelengths) for k, active in activeTrans.items() if active}
+        activeWavelengths = {k: np.ones_like(wavelengths, dtype=np.bool8) for k in transGrids}
+        blueIdx = {k: 0 for k in transGrids}
 
-    def __getitem__(self, name: str) -> 'AtomicState':
-        name = name.upper().ljust(2)
-        return self.atoms[self.indices[name]]
+        def test_atom_active(atom: AtomicModel) -> bool:
+            for t in atom.transitions:
+                if activeTrans[t.transId]:
+                    return True
+            return False
 
-    def __iter__(self) -> 'AtomicStateTableIterator':
-        return AtomicStateTableIterator(self)
+        models = []
+        for atom in self.models:
+            if test_atom_active(atom):
+                models.append(atom)
 
-class AtomicStateTableIterator:
-    def __init__(self, table: AtomicStateTable):
-        self.table = table
-        self.index = 0
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self.index < len(self.table):
-            a = self.table.atoms[self.index]
-            self.index += 1
-            return a
-
-        raise StopIteration
-
+        return SpectrumConfiguration(radSet=self.radSet, wavelength=wavelengths, models=models, transWavelengths=transGrids,
+                                     blueIdx=blueIdx, activeTrans=activeTrans, activeWavelengths=activeWavelengths)
 
 
 @dataclass
@@ -218,48 +132,30 @@ class AtomicState:
     model: AtomicModel
     nStar: np.ndarray
     nTotal: np.ndarray
-    pops: Optional[np.ndarray] = None
-    Rij: Optional[List[np.ndarray]] = None
-    Rji: Optional[List[np.ndarray]] = None
-    lineRij: Optional[List[np.ndarray]] = None
-    lineRji: Optional[List[np.ndarray]] = None
-    continuumRij: Optional[List[np.ndarray]] = None
-    continuumRji: Optional[List[np.ndarray]] = None
+    abundance: float
 
-    def __repr__(self):
-        return 'AtomicModelPops(name=%s(%d), nStar=%s, nTotal=%s, pops=%s)' % (self.model.name, hash(self.model), repr(self.nStar), repr(self.nTotal), repr(self.pops))
+    def __str__(self):
+        s = 'AtomicState(%s)' % str(self.element)
+        return s
 
     def __hash__(self):
-        return hash(repr(self))
+        # return hash(repr(self))
+        raise NotImplementedError
 
-    def update_nTotal(self, atmos):
-        self.nTotal[:] = self.model.atomicTable[self.name].abundance * atmos.nHTot
-
-    @property
-    def name(self):
-        return self.model.name
+    def update_nTotal(self, atmos: Atmosphere):
+        self.nTotal[:] = self.abundance * atmos.nHTot # type: ignore
 
     @property
-    def abundance(self):
-        return self.model.atomicTable[self.model.name].abundance
+    def element(self) -> Element:
+        return self.model.element
 
     @property
-    def weight(self):
-        return self.model.atomicTable[self.model.name].weight
+    def mass(self) -> float:
+        return self.element.mass
 
     @property
     def n(self) -> np.ndarray:
-        if self.pops is not None:
-            return self.pops
-        else:
-            return self.nStar
-
-    @n.setter
-    def n(self, val: np.ndarray):
-        if val.shape != self.nStar.shape:
-            raise ValueError('Incorrect dimensions for population array, expected %s' % repr(self.nStar.shape))
-
-        self.pops = val
+        return self.nStar
 
     def fjk(self, atmos, k):
         # Nstage: int = (self.model.levels[-1].stage - self.model.levels[0].stage) + 1
@@ -291,17 +187,59 @@ class AtomicState:
 
         return fj, dfj
 
+    def set_n_to_lte(self):
+        pass
+
+
+@dataclass
+class DetailedAtomicState(AtomicState):
+    pops: np.ndarray
+    Rij: Dict[Tuple[int, int], np.ndarray] = field(init=False)
+    Rji: Dict[Tuple[int, int], np.ndarray] = field(init=False)
+
+    def __post_init__(self):
+        ratesShape = self.nStar.shape[1:]
+        for t in self.model.transitions:
+            self.Rij[(t.i, t.j)] = np.zeros(ratesShape)
+            self.Rji[(t.i, t.j)] = np.zeros(ratesShape)
+
+    @property
+    def n(self) -> np.ndarray:
+        return self.pops
+
+    def set_n_to_lte(self):
+        self.pops[:] = self.nStar
+
+
+class AtomicStateTable:
+    def __init__(self, atoms: List[AtomicState]):
+        self.atoms = {a.element: a for a in atoms}
+
+    def __contains__(self, name: Union[int, Tuple[int, int], str, Element]) -> bool:
+        x = PeriodicTable[name]
+        return x in self.atoms
+
+    def __len__(self) -> int:
+        return len(self.atoms)
+
+    def __getitem__(self, name: Union[int, Tuple[int, int], str, Element]) -> AtomicState:
+        x = PeriodicTable[name]
+        return self.atoms[x]
+
+    def __iter__(self):
+        return iter(sorted(self.atoms.values, key=element_sort))
+
 
 @dataclass
 class SpeciesStateTable:
     atmosphere: Atmosphere
-    atomicTable: AtomicTable
+    abundance: AtomicAbundance
     atomicPops: AtomicStateTable
     molecularTable: MolecularTable
     molecularPops: List[np.ndarray]
     HminPops: np.ndarray
 
-    def __getitem__(self, name: str) -> np.ndarray:
+    def __getitem__(self, name: Union[int, Tuple[int, int], str, Element]) -> np.ndarray:
         if name == 'H-':
             return self.HminPops
         else:
@@ -310,15 +248,11 @@ class SpeciesStateTable:
                 return self.molecularPops[key]
             elif name in self.atomicPops:
                 return self.atomicPops[name].n
-            else:
-                raise KeyError('Unknown key: %s' % name)
 
-    def __contains__(self, name: Union[str, AtomicModel]) -> bool:
-        if isinstance(name, AtomicModel):
-            name = name.name
+    def __contains__(self, name: Union[int, Tuple[int, int], str, Element]) -> bool:
         if name == 'H-':
             return True
-        
+
         if name in self.molecularTable:
             return True
 
@@ -326,14 +260,6 @@ class SpeciesStateTable:
             return True
 
         return False
-
-    def atomic_population(self, name: str) -> np.ndarray:
-        return self.atomicPops[name].n
-
-    def molecular_population(self, name: str) -> np.ndarray:
-        name = name.upper()
-        key = self.molecularTable.indices[name]
-        return self.molecularPops[key]
 
     def update_lte_atoms_Hmin_pops(self, atmos: Atmosphere, conserveCharge=False, updateTotals=False, maxIter=2000, quiet=False):
         if updateTotals:
@@ -373,174 +299,121 @@ class SpeciesStateTable:
 
         self.HminPops[:] = hminus_pops(atmos, self.atomicPops['H'])
 
-    def update_lte_pops(self, atmos: Atmosphere, conserveCharge=False, updateTotals=False, maxIter=2000):
-        if updateTotals:
-            for atom in self.atomicPops:
-                atom.update_nTotal(atmos)
-        for i in range(maxIter):
-            maxDiff = 0.0
-            ne = np.copy(atmos.ne)
-            for atom in self.atomicPops:
-                prevNStar = np.copy(atom.nStar)
-                newNStar = lte_pops(atom.model, atmos.temperature, atmos.ne, atom.nTotal, debye=True)
-                deltaNStar = newNStar - prevNStar
-                atom.nStar[:] = newNStar
 
-                if atom.pops is None and conserveCharge:
-                    stages = np.array([l.stage for l in atom.model.levels])
-                    ne += np.sum((atom.nStar - prevNStar) * stages[:, None], axis=0)
-
-                    ne[ne < 1e6] = 1e6
-                diff = np.nanmax(1.0 - prevNStar / atom.nStar)
-                if diff > maxDiff:
-                    maxDiff = diff
-                    maxName = atom.name
-            atmos.ne[:] = ne
-            if maxDiff < 1e-3:
-                print('LTE Iterations %d' % (i+1))
-                break
-
-        else:
-            raise ValueError('No convergence in LTE update')
-
-        self.HminPops[:] = hminus_pops(atmos, self.atomicPops['H'])
-
-        
-
-
-@dataclass
 class RadiativeSet:
-    atoms: List[AtomicModel]
-    atomicTable: AtomicTable = field(default_factory=get_global_atomic_table)
-    activeSet: Set[AtomicModel] = field(default_factory=set)
-    detailedStaticSet: Set[AtomicModel] = field(default_factory=set)
-    passiveSet: Set[AtomicModel] = field(init=False)
+    def __init__(self, atoms: List[AtomicModel], abundance: AtomicAbundance=DefaultAtomicAbundance):
+        self.abundance = abundance
+        self.elements = [a.element for a in atoms]
+        self.atoms = {k: v for k, v in zip(self.elements, atoms)}
+        self.passiveSet = set(self.elements)
+        self.detailedStaticSet: Set[Element] = set()
+        self.activeSet: Set[Element] = set()
 
-    def __post_init__(self):
-        self.passiveSet = set(self.atoms)
-        self.atomicNames = []
-        self.atoms = sorted(self.atoms, key=atomic_weight_sort)
-        for atom in self.atoms:
-            self.atomicNames.append(atom.name)
-
-        if len(self.atomicNames) > len(set(self.atomicNames)):
+        if len(self.passiveSet) > len(self.elements):
             raise ValueError('Multiple entries for an atom: %s' % self.atoms)
 
-        self.set_atomic_table(self.atomicTable)
+    def __contains__(self, x: Union[int, Tuple[int, int], str, Element]) -> bool:
+        return PeriodicTable[x] in self.elements
 
-    def __contains__(self, name: str) -> bool:
-        return name in self.atomicNames
+    def is_active(self, name: Union[int, Tuple[int, int], str, Element]) -> bool:
+        x = PeriodicTable[name]
+        return x in self.activeSet
 
-    def is_active(self, name: str) -> bool:
-        if name in self.atomicNames:
-            return self.atoms[self.atomicNames.index(name)] in self.activeSet
-        raise ValueError('Atom %s not present in RadiativeSet' % name)
+    def is_passive(self, name: Union[int, Tuple[int, int], str, Element]) -> bool:
+        x = PeriodicTable[name]
+        return x in self.passiveSet
 
-    def is_passive(self, name: str) -> bool:
-        if name in self.atomicNames:
-            return self.atoms[self.atomicNames.index(name)] in self.passiveSet
-        raise ValueError('Atom %s not present in RadiativeSet' % name)
-
-    def is_detailed(self, name: str) -> bool:
-        if name in self.atomicNames:
-            return self.atoms[self.atomicNames.index(name)] in self.detailedStaticSet
-        raise ValueError('Atom %s not present in RadiativeSet' % name)
+    def is_detailed(self, name: Union[int, Tuple[int, int], str, Element]) -> bool:
+        x = PeriodicTable[name]
+        return x in self.detailedStaticSet
 
     @property
     def activeAtoms(self) -> List[AtomicModel]:
-        activeAtoms : List[AtomicModel] = [a for a in self.activeSet]
-        activeAtoms = sorted(activeAtoms, key=atomic_weight_sort)
+        activeAtoms : List[AtomicModel] = [self.atoms[e] for e in self.activeSet]
+        activeAtoms = sorted(activeAtoms, key=element_sort)
         return activeAtoms
 
     @property
     def detailedAtoms(self) -> List[AtomicModel]:
-        detailedAtoms : List[AtomicModel] = [a for a in self.detailedStaticSet]
-        detailedAtoms = sorted(detailedAtoms, key=atomic_weight_sort)
+        detailedAtoms : List[AtomicModel] = [self.atoms[e] for e in self.detailedStaticSet]
+        detailedAtoms = sorted(detailedAtoms, key=element_sort)
         return detailedAtoms
 
     @property
     def passiveAtoms(self) -> List[AtomicModel]:
-        passiveAtoms : List[AtomicModel] = [a for a in self.passiveSet]
-        passiveAtoms = sorted(passiveAtoms, key=atomic_weight_sort)
+        passiveAtoms : List[AtomicModel] = [self.atoms[e] for e in self.passiveSet]
+        passiveAtoms = sorted(passiveAtoms, key=element_sort)
         return passiveAtoms
 
-    def __getitem__(self, name: str) -> AtomicModel:
-        name = name.upper()
-        if len(name) == 1 and name not in self.atomicNames:
-            name += ' '
+    def __getitem__(self, name: Union[int, Tuple[int, int], str, Element]) -> AtomicModel:
+        x = PeriodicTable[name]
+        return self.atoms[x]
 
-        return self.atoms[self.atomicNames.index(name)]
-    
     def __iter__(self):
-        return iter(self.atoms)
+        return iter(self.atoms.values())
 
-    def rehash(self):
-        self.activeSet = set([x for x in self.activeSet])
-        self.passiveSet = set([x for x in self.passiveSet])
-        self.detailedStaticSet = set([x for x in self.detailedStaticSet])
-
-    def validate_sets(self, rehashed=False):
-        if (self.activeSet | self.passiveSet | self.detailedStaticSet) != set(self.atoms):
-            if not rehashed:
-                self.rehash()
-                self.validate_sets(rehashed=True)
-                return
-
-            raise ValueError('Problem with distribution of Atoms inside AtomicSet')
-    
     def set_active(self, *args: str):
         names = set(args)
-        for atomName in names:
-            self.activeSet.add(self[atomName])
-            self.detailedStaticSet.discard(self[atomName])
-            self.passiveSet.discard(self[atomName])
-        self.validate_sets()
+        xs = [PeriodicTable[name] for name in names]
+        for x in xs:
+            self.activeSet.add(x)
+            self.detailedStaticSet.discard(x)
+            self.passiveSet.discard(x)
 
     def set_detailed_static(self, *args: str):
         names = set(args)
-        for atomName in names:
-            self.detailedStaticSet.add(self[atomName])
-            self.activeSet.discard(self[atomName])
-            self.passiveSet.discard(self[atomName])
-        self.validate_sets()
+        xs = [PeriodicTable[name] for name in names]
+        for x in xs:
+            self.detailedStaticSet.add(x)
+            self.activeSet.discard(x)
+            self.passiveSet.discard(x)
 
     def set_passive(self, *args: str):
         names = set(args)
-        for atomName in names:
-            self.passiveSet.add(self[atomName])
-            self.activeSet.discard(self[atomName])
-            self.detailedStaticSet.discard(self[atomName])
-        self.validate_sets()
+        xs = [PeriodicTable[name] for name in names]
+        for x in xs:
+            self.passiveSet.add(x)
+            self.activeSet.discard(x)
+            self.detailedStaticSet.discard(x)
 
-    def set_atomic_table(self, table: AtomicTable):
-        self.atomicTable = table
-        for a in self.atoms:
-            if a.atomicTable is self.atomicTable:
-                continue
-            a.replace_atomic_table(self.atomicTable)
-
-    def iterate_lte_ne_eq_pops(self, atmos: Atmosphere, 
+    def iterate_lte_ne_eq_pops(self, atmos: Atmosphere,
                                mols: Optional[MolecularTable]=None,
-                               direct: bool=False):
+                               nlteStartingPops: Optional[Dict[Element, np.ndarray]]=None,
+                               direct: bool=False) -> SpeciesStateTable:
         if mols is None:
             mols = MolecularTable([])
+
+        if nlteStartingPops is None:
+            nlteStartingPops = {}
+        else:
+            for e in nlteStartingPops:
+                if (e not in self.activeSet) \
+                   or (e not in self.detailedStaticSet):
+                    raise ValueError('Provided NLTE Populations for %s assumed LTE.' % e)
 
         if direct:
             maxIter = 3000
             prevNe = np.copy(atmos.ne)
             ne = np.copy(atmos.ne)
+            atoms = sorted(self.atoms.values(), key=element_sort)
             for it in range(maxIter):
                 atomicPops = []
                 prevNe[:] = ne
                 ne.fill(0.0)
-                for a in sorted(self.atoms, key=atomic_weight_sort):
-                    nTotal = self.atomicTable[a.name].abundance * atmos.nHTot
+                for a in atoms:
+                    abund = self.abundance[a.element]
+                    nTotal = abund * atmos.nHTot
                     nStar = lte_pops(a, atmos.temperature, atmos.ne, nTotal, debye=True)
-                    atomicPops.append(AtomicState(a, nStar, nTotal))
+                    atomicPops.append(AtomicState(a, nStar, nTotal, abundance=abund))
+
+                    # NOTE(cmo): Take into account NLTE pops if provided
+                    if a.element in nlteStartingPops:
+                        if nlteStartingPops[a.element].shape != nStar:
+                            raise ValueError('Starting populations provided for %s do not match model.' % e)
+                        nStar = nlteStartingPops[a.element]
+
                     stages = np.array([l.stage for l in a.levels])
-                    # print(stages)
                     ne += np.sum(nStar * stages[:, None], axis=0)
-                    # print(ne)
                 atmos.ne[:] = ne
 
                 relDiff = np.nanmax(np.abs(1.0 - prevNe / ne))
@@ -552,33 +425,69 @@ class RadiativeSet:
             else:
                 print("LTE ne failed to converge")
         else:
-            ne = np.copy(atmos.ne) / atmos.nHTot
-            iterator = LteNeIterator(self.atoms, atmos.temperature, atmos.nHTot)
-            ne += iterator(ne)
-            newNe = newton_krylov(iterator, ne)
-            atmos.ne[:] = newNe * atmos.nHTot
+            neRatio = np.copy(atmos.ne) / atmos.nHTot
+            iterator = LteNeIterator(self.atoms.values(), atmos.temperature,
+                                     atmos.nHTot, self.abundance, nlteStartingPops)
+            neRatio += iterator(neRatio)
+            newNeRatio = newton_krylov(iterator, neRatio)
+            atmos.ne[:] = newNeRatio * atmos.nHTot
 
             atomicPops = iterator.atomicPops
 
-        table = AtomicStateTable(atomicPops)
-        eqPops = chemical_equilibrium_fixed_ne(atmos, mols, table, self.atoms[0].atomicTable)
-        # NOTE(cmo): This is technically not quite correct, because we adjust nTotal and the atomic populations to account for the atoms bound up in molecules, but not n_e, this is unlikely to make much difference in reality, other than in very cool atmospheres with a lot of molecules (even then it should be pretty tiny)
+        detailedAtomicPops = []
+        for pop in atomicPops:
+            ele = pop.model.element
+            if ele in self.passiveSet:
+                detailedAtomicPops.append(pop)
+            else:
+                nltePops = np.copy(nlteStartingPops[ele]) if ele in nlteStartingPops else np.copy(pop.nStar)
+                detailedAtomicPops.append(DetailedAtomicState(model=pop.model, nStar=pop.nStar, nTotal=pop.nTotal,
+                                                              pops=nltePops, abundance=self.abundance[ele]))
+
+        table = AtomicStateTable(detailedAtomicPops)
+        eqPops = chemical_equilibrium_fixed_ne(atmos, mols, table, self.abundance)
+        # NOTE(cmo): This is technically not quite correct, because we adjust
+        # nTotal and the atomic populations to account for the atoms bound up
+        # in molecules, but not n_e, this is unlikely to make much difference
+        # in reality, other than in very cool atmospheres with a lot of
+        # molecules (even then it should be pretty tiny)
         return eqPops
 
     def compute_eq_pops(self, atmos: Atmosphere,
+                        nlteStartingPops: Optional[Dict[Element, np.ndarray]]=None,
                         mols: Optional[MolecularTable]=None):
         if mols is None:
             mols = MolecularTable([])
 
+        if nlteStartingPops is None:
+            nlteStartingPops = {}
+        else:
+            for e in nlteStartingPops:
+                if (e not in self.activeSet) \
+                   or (e not in self.detailedStaticSet):
+                    raise ValueError('Provided NLTE Populations for %s assumed LTE.' % e)
+
         atomicPops = []
-        for a in sorted(self.atoms, key=atomic_weight_sort):
-            nTotal = a.atomicTable[a.name].abundance * atmos.nHTot
+        atoms = sorted(self.atoms.values(), key=element_sort)
+        for a in atoms:
+            nTotal = self.abundance[a.element] * atmos.nHTot
             nStar = lte_pops(a, atmos.temperature, atmos.ne, nTotal, debye=True)
-            atomicPops.append(AtomicState(a, nStar, nTotal))
+
+            ele = a.element
+            if ele in self.passiveSet:
+                atomicPops.append(AtomicState(a, nStar, nTotal, abundance=self.abundance[ele]))
+            else:
+                nltePops = np.copy(nlteStartingPops[ele]) if ele in nlteStartingPops else np.copy(nStar)
+                atomicPops.append(DetailedAtomicState(model=a, nStar=nStar, nTotal=nTotal,
+                                                      pops=nltePops, abundance=self.abundance[ele]))
 
         table = AtomicStateTable(atomicPops)
-        eqPops = chemical_equilibrium_fixed_ne(atmos, mols, table, self.atoms[0].atomicTable)
-        # NOTE(cmo): This is technically not quite correct, because we adjust nTotal and the atomic populations to account for the atoms bound up in molecules, but not n_e, this is unlikely to make much difference in reality, other than in very cool atmospheres with a lot of molecules (even then it should be pretty tiny)
+        eqPops = chemical_equilibrium_fixed_ne(atmos, mols, table, self.abundance)
+        # NOTE(cmo): This is technically not quite correct, because we adjust
+        # nTotal and the atomic populations to account for the atoms bound up
+        # in molecules, but not n_e, this is unlikely to make much difference
+        # in reality, other than in very cool atmospheres with a lot of
+        # molecules (even then it should be pretty tiny)
         return eqPops
 
     def compute_wavelength_grid(self, extraWavelengths: Optional[np.ndarray]=None, lambdaReference=500.0) -> SpectrumConfiguration:
@@ -590,83 +499,43 @@ class RadiativeSet:
         grids.append(np.array([lambdaReference]))
 
         models: List[AtomicModel] = []
-        transitions: List[Union[AtomicLine, AtomicContinuum]] = []
-        continuaPerAtom: Dict[str, List[List[AtomicContinuum]]] = {}
-        linesPerAtom: Dict[str, List[List[AtomicLine]]]= {}
-        upperLevels: Dict[str, List[Set[int]]] = {}
-        lowerLevels: Dict[str, List[Set[int]]] = {}
+        ids: List[Tuple[Element, int, int]] = []
 
-        for atom in (self.activeSet | self.detailedStaticSet):
+        for ele in (self.activeSet | self.detailedStaticSet):
+            atom = self.atoms[ele]
             models.append(atom)
-            continuaPerAtom[atom.name] = []
-            linesPerAtom[atom.name] = []
-            lowerLevels[atom.name] = []
-            upperLevels[atom.name] = []
-            for line in atom.lines:
-                transitions.append(line)
-                grids.append(line.wavelength)
-            for cont in atom.continua:
-                transitions.append(cont)
-                grids.append(np.array([cont.lambdaEdge]))
-                grids.append(cont.wavelength[cont.wavelength <= cont.lambdaEdge])
-
-        # for atom in self.detailedLteSet:
-        #     for line in atom.lines:
-        #         grids.append(line.wavelength)
-        #     for cont in atom.continua:
-        #         grids.append(cont.wavelength)
+            for trans in atom.transitions:
+                grids.append(trans.wavelength())
+                ids.append(trans.transId)
 
         grid = np.concatenate(grids)
         grid = np.sort(grid)
         grid = np.unique(grid)
         # grid = np.unique(np.floor(1e10*grid)) / 1e10
-        blueIdx = []
-        redIdx = []
+        blueIdx = {}
+        redIdx = {}
 
-        for t in transitions:
-            blueIdx.append(np.searchsorted(grid, t.wavelength[0]))
-            redIdx.append(np.searchsorted(grid, t.wavelength[-1])+1)
+        for i, g in enumerate(grids):
+            ident = ids[i]
+            blueIdx[ident] = np.searchsorted(grid, g[0])
+            redIdx[ident] = np.searchsorted(grid, g[-1])+1
 
-        for i, t in enumerate(transitions):
-            # NOTE(cmo): Some continua have wavelength grids that go past their edge. Let's avoid that.
-            if isinstance(t, AtomicContinuum):
-                while grid[redIdx[i]-1] > t.lambdaEdge:
-                    redIdx[i] -= 1
-            wavelength = np.copy(grid[blueIdx[i]:redIdx[i]])
-            if isinstance(t, AtomicContinuum):
-                t.alpha = t.compute_alpha(wavelength)
-            t.wavelength = wavelength
+        transGrids: Dict[Tuple[Element, int, int], np.ndarray] = {}
+        for ident in ids:
+            transGrids[ident] = np.copy(grid[blueIdx[ident]:redIdx[ident]])
 
-        activeSet: List[List[Union[AtomicLine, AtomicContinuum]]] = []
-        activeLines: List[List[AtomicLine]] = []
-        activeContinua: List[List[AtomicContinuum]] = []
-        contributors: List[List[AtomicModel]] = []
-        for i in range(grid.shape[0]):
-            activeSet.append([])
-            activeLines.append([])
-            activeContinua.append([])
-            contributors.append([])
-            for atom in (self.activeSet | self.detailedStaticSet):
-                continuaPerAtom[atom.name].append([])
-                linesPerAtom[atom.name].append([])
-                upperLevels[atom.name].append(set())
-                lowerLevels[atom.name].append(set())
-            for kr, t in enumerate(transitions):
-                if blueIdx[kr] <= i < redIdx[kr]:
-                    activeSet[-1].append(t)
-                    contributors[-1].append(t.atom)
-                    if isinstance(t, AtomicContinuum):
-                        activeContinua[-1].append(t)
-                        continuaPerAtom[t.atom.name][-1].append(t)
-                        upperLevels[t.atom.name][-1].add(t.j)
-                        lowerLevels[t.atom.name][-1].add(t.i)
-                    elif isinstance(t, AtomicLine):
-                        activeLines[-1].append(t)
-                        linesPerAtom[t.atom.name][-1].append(t)
-                        upperLevels[t.atom.name][-1].add(t.j)
-                        lowerLevels[t.atom.name][-1].add(t.i)
+        contAlpha: Dict[Tuple[Element, int, int], np.ndarray] = {}
+        for ele in (self.activeSet | self.detailedStaticSet):
+            atom = self.atoms[ele]
+            for cont in atom.continua:
+                ident = cont.transId
+                contAlpha[ident] = cont.alpha(transGrids[ident])
 
-        return SpectrumConfiguration(radSet=self, wavelength=grid, transitions=transitions, models=models, blueIdx=blueIdx, activeSet=activeSet)
+        activeWavelengths = {k: ((grid >= v[0]) & (grid <= v[-1])) for k, v in transGrids.items()}
+        activeTrans = {k: True for k in transGrids}
+
+        return SpectrumConfiguration(radSet=self, wavelength=grid, models=models, transWavelengths=transGrids,
+                                     blueIdx=blueIdx, activeTrans=activeTrans, activeWavelengths=activeWavelengths)
 
 
 def hminus_pops(atmos: Atmosphere, hPops: AtomicState) -> np.ndarray:
@@ -681,28 +550,33 @@ def hminus_pops(atmos: Atmosphere, hPops: AtomicState) -> np.ndarray:
 
     return HminPops
 
-def chemical_equilibrium_fixed_ne(atmos: Atmosphere, molecules: MolecularTable, atomicPops: AtomicStateTable, table: AtomicTable) -> SpeciesStateTable:
+def chemical_equilibrium_fixed_ne(atmos: Atmosphere, molecules: MolecularTable, atomicPops: AtomicStateTable, abundance: AtomicAbundance) -> SpeciesStateTable:
     nucleiSet: Set[Element] = set()
     for mol in molecules:
         nucleiSet |= set(mol.elements)
-    nuclei: List[Union[Element, AtomicState]]= list(nucleiSet)
-    nuclei = sorted(nuclei, key=atomic_weight_sort)
+    nuclei: List[Element] = list(nucleiSet)
+    nuclei = sorted(nuclei)
 
     if len(nuclei) == 0:
         HminPops = hminus_pops(atmos, atomicPops['H'])
-        result = SpeciesStateTable(atmos, table, atomicPops, molecules, [], HminPops)
+        result = SpeciesStateTable(atmos, abundance, atomicPops, molecules, [], HminPops)
         return result
 
-    if not nuclei[0].name.startswith('H'):
+    if nuclei[0] != PeriodicTable[0]:
         raise ValueError('H not list of nuclei -- check H2 molecule')
-    print([n.name for n in nuclei])
+    # print([n.name for n in nuclei])
 
     nuclIndex = [[nuclei.index(ele) for ele in mol.elements] for mol in molecules]
 
     # Replace basic elements with full Models if present
-    for i, nuc in enumerate(nuclei):
-        if nuc.name in atomicPops:
-            nuclei[i] = atomicPops[nuc.name]
+    kuruczTable = KuruczPfTable(atomicAbundance=abundance)
+    nucData: Dict[Element, Union[KuruczPf, AtomicState]] = {}
+    for nuc in nuclei:
+        if nuc in atomicPops:
+            nucData[nuc] = atomicPops[nuc]
+        else:
+            nucData[nuc] = kuruczTable[nuc]
+
     Nnuclei = len(nuclei)
 
     Neqn = Nnuclei + len(molecules)
@@ -722,9 +596,10 @@ def chemical_equilibrium_fixed_ne(atmos: Atmosphere, molecules: MolecularTable, 
     molPops = [np.zeros(Nspace) for mol in molecules]
     maxIter = 0
     for k in range(Nspace):
-        for i in range(Nnuclei):
-            a[i] = nuclei[i].abundance * atmos.nHTot[k]
-            fjk, dfjk = nuclei[i].fjk(atmos, k)
+        for i, nuc in enumerate(nuclei):
+            nucleus = nucData[nuc]
+            a[i] = nucleus.abundance * atmos.nHTot[k]
+            fjk, dfjk = nucleus.fjk(atmos, k)
             fn0[i] = fjk[0]
 
         PhiHmin = 0.25 * (CI / atmos.temperature[k])**1.5 \
@@ -794,19 +669,19 @@ def chemical_equilibrium_fixed_ne(atmos: Atmosphere, molecules: MolecularTable, 
             raise ValueError("ChemEq iteration not converged: T: %e [K], density %e [m^-3], dnmax %e" % (atmos.temperature[k], atmos.nHTot[k], dnMax))
 
         for i, ele in enumerate(nuclei):
-            if ele.name in atomicPops:
-                atomPop = atomicPops[ele.name]
+            if ele in atomicPops:
+                atomPop = atomicPops[ele]
                 fraction = n[i] / atomPop.nTotal[k]
                 atomPop.nStar[:, k] *= fraction
                 atomPop.nTotal[k] *= fraction
-                if atomPop.pops is not None:
+                if isinstance(atomPop, DetailedAtomicState):
                     atomPop.pops[:, k] *= fraction
 
         HminPops[k] = atmos.ne[k] * n[0] * PhiHmin
 
         for i, pop in enumerate(molPops):
-            pop[k] = n[Nnuclei + i] 
+            pop[k] = n[Nnuclei + i]
 
-    result = SpeciesStateTable(atmos, table, atomicPops, molecules, molPops, HminPops)
-    print("Maximum number of iterations taken: %d" % maxIter)
+    result = SpeciesStateTable(atmos, abundance, atomicPops, molecules, molPops, HminPops)
+    print("chem_eq: maximum number of iterations taken: %d" % maxIter)
     return result

--- a/lightweaver/atomic_table.py
+++ b/lightweaver/atomic_table.py
@@ -1,205 +1,294 @@
-from typing import Dict, Optional, List, TYPE_CHECKING
+from typing import Dict, Optional, List, Union, Tuple, TYPE_CHECKING
 from copy import copy, deepcopy
 from collections import OrderedDict
 from xdrlib import Unpacker
 from dataclasses import dataclass, field
 import numpy as np
-import lightweaver.constants as Const
 from scipy.interpolate import interp1d
-from numba import jit
-from .utils import ConvergenceError, get_data_path
+import pickle
+import lightweaver.constants as Const
+from .utils import get_data_path
 
 if TYPE_CHECKING:
-    from .atomic_model import AtomicModel
     from .atmosphere import Atmosphere
 
-AtomicWeights = OrderedDict([
-    ("H ", 1.008),   ("HE", 4.003),   ("LI", 6.939),   ("BE", 9.013),
-    ("B ", 10.810),  ("C ", 12.010),  ("N ", 14.010),  ("O ", 16.000),
-    ("F ", 19.000),  ("NE", 20.180),  ("NA", 22.990),  ("MG", 24.310),
-    ("AL", 26.980),  ("SI", 28.090),  ("P ", 30.980),  ("S ", 32.070),
-    ("CL", 35.450),  ("AR", 39.950),  ("K ", 39.100),  ("CA", 40.080),
-    ("SC", 44.960),  ("TI", 47.900),  ("V ", 50.940),  ("CR", 52.000),
-    ("MN", 54.940),  ("FE", 55.850),  ("CO", 58.940),  ("NI", 58.710),
-    ("CU", 63.550),  ("ZN", 65.370),  ("GA", 69.720),  ("GE", 72.600),
-    ("AS", 74.920),  ("SE", 78.960),  ("BR", 79.910),  ("KR", 83.800),
-    ("RB", 85.480),  ("SR", 87.630),  ("Y ", 88.910),  ("ZR", 91.220),
-    ("NB", 92.910),  ("MO", 95.950),  ("TC", 99.000),  ("RU", 101.100),
-    ("RH", 102.900), ("PD", 106.400), ("AG", 107.900), ("CD", 112.400),
-    ("IN", 114.800), ("SN", 118.700), ("SB", 121.800), ("TE", 127.600),
-    ("I ", 126.900), ("XE", 131.300), ("CS", 132.900), ("BA", 137.400),
-    ("LA", 138.900), ("CE", 140.100), ("PR", 140.900), ("ND", 144.300),
-    ("PM", 147.000), ("SM", 150.400), ("EU", 152.000), ("GD", 157.300),
-    ("TB", 158.900), ("DY", 162.500), ("HO", 164.900), ("ER", 167.300),
-    ("TM", 168.900), ("YB", 173.000), ("LU", 175.000), ("HF", 178.500),
-    ("TA", 181.000), ("W ", 183.900), ("RE", 186.300), ("OS", 190.200),
-    ("IR", 192.200), ("PT", 195.100), ("AU", 197.000), ("HG", 200.600),
-    ("TL", 204.400), ("PB", 207.200), ("BI", 209.000), ("PO", 210.000),
-    ("AT", 211.000), ("RN", 222.000), ("FR", 223.000), ("RA", 226.100),
-    ("AC", 227.100), ("TH", 232.000), ("PA", 231.000), ("U ", 238.000),
-    ("NP", 237.000), ("PU", 244.000), ("AM", 243.000), ("CM", 247.000),
-    ("BK", 247.000), ("CF", 251.000), ("ES", 254.000)])
-
-def atomic_weight_sort(atom):
-    name = atom.name.upper().ljust(2)
-    return AtomicWeights[name]
-
-# def weight_amu(name: str):
-#    name = name.upper()
-#    if len(name) == 1:
-#       name += ' '
-#    return AtomicWeights[name]
-
-## NA   6.73  ## Value needed for small Na I atom
-# O   8.93  # original
-# C   8.60  # original
-# FE   7.67  #original
-AtomicAbundances = \
-OrderedDict([
-("H ", 12.00),
-("HE", 10.99),
-("LI",  1.16),
-("BE",  1.15),
-("B ",  2.60),
-("C ",  8.39),  ## Asplund et al 2005, A&A, 431, 693-705
-("N ",  8.00),
-("O ",  8.66),  ## Asplund et al 2004, A&A, 417, 751
-("F ",  4.40),  ## for Kurucz model T4250, vt=0.5
-("NE",  8.09),
-("NA",  6.33),
-("MG",  7.58),
-("AL",  6.47),
-("SI",  7.55),
-("P ",  5.45),
-("S ",  7.21),
-("CL",  5.50),
-("AR",  6.56),
-("K ",  5.12),
-("CA",  6.36),
-("SC",  3.10),
-("TI",  4.99),
-("V ",  4.00),
-("CR",  5.67),
-("MN",  5.39),
-("FE",  7.44),  ## Asplund et al 2000, A&A, 359, 743
-("CO",  4.92),
-("NI",  6.25),
-("CU",  4.21),
-("ZN",  4.60),
-("GA",  2.88),
-("GE",  3.41),
-("AS",  2.37),
-("SE",  3.35),
-("BR",  2.63),
-("KR",  3.23),
-("RB",  2.60),
-("SR",  2.90),
-("Y ",  2.24),
-("ZR",  2.60),
-("NB",  1.42),
-("MO",  1.92),
-("TC", -7.96),
-("RU",  1.84),
-("RH",  1.12),
-("PD",  1.69),
-("AG",  0.94),
-("CD",  1.86),
-("IN",  1.66),
-("SN",  2.00),
-("SB",  1.00),
-("TE",  2.24),
-("I ",  1.51),
-("XE",  2.23),
-("CS",  1.12),
-("BA",  2.13),
-("LA",  1.22),
-("CE",  1.55),
-("PR",  0.71),
-("ND",  1.50),
-("PM", -7.96),
-("SM",  1.00),
-("EU",  0.51),
-("GD",  1.12),
-("TB", -0.10),
-("DY",  1.10),
-("HO",  0.26),
-("ER",  0.93),
-("TM",  0.00),
-("YB",  1.08),
-("LU",  0.76),
-("HF",  0.88),
-("TA",  0.13),
-("W ",  1.11),
-("RE",  0.27),
-("OS",  1.45),
-("IR",  1.35),
-("PT",  1.80),
-("AU",  1.01),
-("HG",  1.09),
-("TL",  0.90),
-("PB",  1.85),
-("BI",  0.71),
-("PO", -7.96),
-("AT", -7.96),
-("RN", -7.96),
-("FR", -7.96),
-("RA", -7.96),
-("AC", -7.96),
-("TH",  0.12),
-("PA", -7.96),
-("U ", -0.47),
-("NP", -7.96),
-("PU", -7.96),
-("AM", -7.96),
-("CM", -7.96),
-("BK", -7.96),
-("CF", -7.96),
-("ES", -7.96)])
-
-def read_pf(path):
-    with open(path, 'rb') as f:
-        s = f.read()
-    u = Unpacker(s)
-    Tpf = u.unpack_array(u.unpack_double)
-    ptis = []
-    stages = []
-    pf = []
-    ionpot = []
-    for i in range(len(AtomicWeights)):
-        ptis.append(u.unpack_int())
-        stages.append(u.unpack_int())
-        pf.append(u.unpack_farray(stages[-1] * len(Tpf), u.unpack_double))
-        ionpot.append(u.unpack_farray(stages[-1], u.unpack_double))
-
-    return {'Tpf': Tpf, 'stages': stages, 'pf': pf, 'ionpot': ionpot}
-
-@dataclass
 class Element:
-    name: str
-    weight: float
-    abundance: float
-    ionpot: np.ndarray
-    Tpf: np.ndarray
-    pf: np.ndarray
-
-    def __post_init__(self):
-        Nstage = self.ionpot.shape[0]
+    def __init__(self, Z: int):
+        self.Z = Z
 
     def __hash__(self):
-        return hash(repr(self))
+        return hash(self.Z)
 
-    def __cmp__(self, other):
-        return hash(self) == hash(other)
+    def __eq__(self, other):
+        return self.Z == other.Z
+
+    def __lt__(self, other):
+        return self.Z < other.Z
 
     def __repr__(self):
-        return 'Element(name=\'%s\', weight=%e, abundance=%e)' % (self.name, self.weight, self.abundance)
+        return '%s(Z=%d)' % (self.name, self.Z)
 
-    def lte_populations(self, atmos: 'Atmosphere') -> np.ndarray:
-        Nstage = self.ionpot.shape[0]
+    @property
+    def mass(self):
+        return PeriodicTable.massData[self.Z]
+
+    @property
+    def name(self):
+        return PeriodicTable.nameMapping[self.Z]
+
+class Isotope(Element):
+    def __init__(self, N, Z):
+        super().__init__(Z)
+        self.N = N
+
+    def __hash__(self):
+        return hash((self.N, self.Z))
+
+    def __eq__(self, other):
+        return self.N == other.N and self.Z == other.Z
+
+    def __lt__(self, other):
+        return (self.Z, self.N) < (other.Z, other.N)
+
+    def __repr__(self):
+        return '%s(N=%d, Z=%d)' % (self.element_name, self.N, self.Z)
+
+    @property
+    def mass(self):
+        return PeriodicTable.massData[(self.N, self.Z)]
+
+    @property
+    def name(self):
+        # NOTE(cmo): Handle H isotopes
+        if self.Z == 1 and self.N != 1:
+            return PeriodicTable.nameMapping[(self.N, self.Z)]
+
+        baseName = self.element_name
+        return '^%d_%s' % (self.N, baseName)
+
+    @property
+    def element(self):
+        return PeriodicTable[self.Z]
+
+    @property
+    def element_mass(self):
+        return super().mass
+
+    @property
+    def element_name(self):
+        return super().name
+
+def load_periodic_table_data():
+    path = get_data_path() + 'AtomicMassesNames.pickle'
+    with open(path, 'rb') as pkl:
+        massData, nameMapping = pickle.load(pkl)
+
+    # NOTE(cmo): Manually change names to D and T for H isotopes
+    nameMapping[(2, 1)] = 'D'
+    nameMapping['D'] = (2, 1)
+    nameMapping[(3, 1)] = 'T'
+    nameMapping['T'] = (3, 1)
+
+    # NOTE(cmo): Compute list of isotopes for each eleemnt.
+    # This can definitely be done more efficiently, but it probably doesn't
+    # matter. (~5 ms, done once, on startup, from timeit)
+    isotopes = {}
+    elements = {}
+    for target in massData:
+        if isinstance(target, tuple):
+            continue
+
+        element = Element(Z=target)
+        elements[target] = element
+        isotopes[element] = []
+        for key in massData:
+            if isinstance(key, int):
+                continue
+
+            if key[1] == target:
+                N, Z = key[0], element.Z
+                iso = Isotope(N=N, Z=Z)
+                isotopes[element].append(iso)
+                elements[(N, Z)] = iso
+    return massData, nameMapping, isotopes, elements
+
+def normalise_atom_name(n: str) -> str:
+    strlen = len(n)
+    if strlen > 2 or strlen == 0:
+        raise ValueError('%s does not represent valid Element name' % n)
+    elif strlen == 1:
+        return n[0].upper()
+    else:
+        return n[0].upper() + n[1].lower()
+
+class PeriodicTableData:
+    massData, nameMapping, isos, elems = load_periodic_table_data()
+
+    def __getitem__(self, x: Union[str, int, Tuple[int, int], Element]) -> Element:
+        if isinstance(x, Element):
+            return x
+
+        if isinstance(x, int):
+            try:
+                return self.elems[x]
+            except KeyError:
+                raise ValueError('Unable to find Element with Z=%d' % x)
+
+        if isinstance(x, tuple) and all(isinstance(y, int) for y in x):
+            try:
+                return self.elems[x]
+            except KeyError:
+                raise ValueError('Unable to find Isotope with (N=%d, Z=%d)' % x)
+
+        if isinstance(x, str):
+            x = x.strip()
+            if x.startswith('^'):
+                terms = x[1:].split('_')
+                if len(terms) != 2:
+                    raise ValueError('Unable to parse Isotope string %s' % x)
+                N = int(terms[0])
+                name = normalise_atom_name(terms[1])
+                try:
+                    Z = self.nameMapping[name]
+                    return self.elems[(N, Z)]
+                except KeyError:
+                    raise ValueError('Unable to find Isotope from string %s' % x)
+            else:
+                name = normalise_atom_name(x)
+                try:
+                    Z = self.nameMapping[name]
+                    return self.elems[Z]
+                except KeyError:
+                    raise ValueError('Unable to find Element with name %s' % name)
+
+        raise ValueError('Cannot find element from %s' % repr(x))
+
+
+    @classmethod
+    def get_isotopes(cls, e: Element) -> List[Isotope]:
+        if not isinstance(e, Element):
+            raise ValueError('Requires Element as first argument, got %s' % repr(e))
+
+        if isinstance(e, Isotope):
+            return cls.isos[e.element]
+
+        return cls.isos[e]
+
+    @property
+    def elements(self):
+        return sorted([e for _, e in self.elems.items() if type(e) is Element])
+
+    @property
+    def isotopes(self):
+        return sorted([e for _, e in self.elems.items() if type(e) is Isotope])
+
+    @property
+    def nuclides(self):
+        return self.elements + self.isotopes
+
+PeriodicTable = PeriodicTableData()
+
+class AtomicAbundance:
+    def __init__(self, abundanceData: dict=None, abundDex=True, metallicity: float=0.0):
+        self.abundance = self.load_default_abundance_data()
+        # NOTE(cmo): Default abundances always in dex
+        self.dex_to_decimal(self.abundance)
+
+        if abundanceData is not None:
+            if abundDex:
+                self.dex_to_decimal(abundanceData)
+            self.abundance.update(abundanceData)
+
+        self.metallicity = metallicity
+        if metallicity != 0.0:
+            self.apply_metallicity(self.abundance, metallicity)
+
+        self.isotopeProportions = {iso: v for iso, v in self.abundance.items() if type(iso) is Isotope}
+
+        self.convert_isotopes_to_abundances()
+        self.compute_stats()
+
+    def convert_isotopes_to_abundances(self):
+        for e in PeriodicTable.elements:
+            totalProp = 0.0
+            isos = PeriodicTable.get_isotopes(e)
+            for iso in isos:
+                totalProp += self.abundance[iso]
+            for iso in isos:
+                if totalProp != 0.0:
+                    self.abundance[iso] /= totalProp
+                    self.abundance[iso] *= self.abundance[e]
+
+    def compute_stats(self):
+        totalAbund = 0.0
+        avgMass = 0.0
+        for e in PeriodicTable.elements:
+            totalAbund += self.abundance[e]
+            avgMass += self.abundance[e] * e.mass
+
+        self.totalAbundance = totalAbund
+        self.massPerH = avgMass
+        self.avgMass = avgMass / totalAbund
+
+    def __getitem__(self, x: Union[str, int, Tuple[int, int], Element]) -> float:
+        return self.abundance[PeriodicTable[x]]
+
+    @staticmethod
+    def dex_to_decimal(abunds):
+        for e, v in abunds.items():
+            if type(e) is Element:
+                abunds[e] = 10**(v - 12.0)
+
+    @staticmethod
+    def apply_metallicity(abunds, metallicity):
+        m = 10**metallicity
+        for e, v in abunds.items():
+            if type(e) is Element and e.Z > 2:
+                abunds[e] *= m
+
+    @staticmethod
+    def load_default_abundance_data() -> dict:
+        """
+        Load the default abundances and convert to required format for
+        AtomicAbundance class (i.e. dict where dict[Element] = abundance, and
+        dict[Isotope] = isotope fraction).
+        """
+        with open(get_data_path() + 'AbundancesAsplund09.pickle', 'rb') as pkl:
+            abundances = pickle.load(pkl)
+
+        lwAbundances = {}
+        for ele in abundances:
+            Z = ele['elem']['elem']['Z']
+            abund = ele['elem']['abundance']
+            lwAbundances[PeriodicTable[Z]] = abund
+
+            for iso in ele['isotopes']:
+                N = iso['N']
+                prop = iso['proportion']
+                lwAbundances[PeriodicTable[(N, Z)]] = prop
+
+        for e in PeriodicTable.nuclides:
+            if e not in lwAbundances:
+                lwAbundances[e] = 0.0
+
+        return lwAbundances
+
+DefaultAtomicAbundance = AtomicAbundance()
+
+@dataclass
+class KuruczPf:
+    element: Element
+    abundance: float
+    Tpf: np.ndarray
+    pf: np.ndarray
+    ionPot: np.ndarray
+
+    def lte_ionisation(self, atmos: 'Atmosphere') -> np.ndarray:
+        Nstage = self.ionPot.shape[0]
         Nspace = atmos.depthScale.shape[0]
 
         C1 = (Const.HPlanck / (2.0 * np.pi * Const.MElectron)) * Const.HPlanck / Const.KBoltzmann
-        
+
         CtNe = 2.0 * (C1/atmos.temperature)**(-1.5) / atmos.ne
         total = np.ones(Nspace)
         pops = np.zeros((Nstage, Nspace))
@@ -210,7 +299,7 @@ class Element:
         for i in range(1, Nstage):
             Ukp1 = np.interp(atmos.temperature, self.Tpf, self.pf[i, :])
 
-            pops[i, :] = pops[i-1, :] * CtNe * np.exp(Ukp1 - Uk - self.ionpot[i-1] \
+            pops[i, :] = pops[i-1, :] * CtNe * np.exp(Ukp1 - Uk - self.ionPot[i-1] \
                             / (Const.KBoltzmann * atmos.temperature))
             total += pops[i]
 
@@ -221,16 +310,15 @@ class Element:
 
         return pops
 
-   # @jit
-    def fjk(self, atmos, k):
+    def fjk(self, atmos: 'Atmosphere', k: int) -> Tuple[np.ndarray, np.ndarray]:
         Nspace: int = atmos.depthScale.shape[0]
         T: float = atmos.temperature[k]
         ne: float = atmos.ne[k]
 
         C1 = (Const.HPlanck / (2.0 * np.pi * Const.MElectron)) * Const.HPlanck / Const.KBoltzmann
-        
+
         CtNe = 2.0 * (C1/T)**(-1.5) / ne
-        Nstage: int = self.ionpot.shape[0]
+        Nstage: int = self.ionPot.shape[0]
         fjk = np.zeros(Nstage)
         fjk[0] = 1.0
         dfjk = np.zeros(Nstage)
@@ -243,7 +331,7 @@ class Element:
         for j in range(1, Nstage):
             Ukp1: float = np.interp(T, self.Tpf, self.pf[j, :])
 
-            fjk[j] = fjk[j-1] * CtNe * np.exp(Ukp1 - Uk - self.ionpot[j-1] / (Const.KBoltzmann * T))
+            fjk[j] = fjk[j-1] * CtNe * np.exp(Ukp1 - Uk - self.ionPot[j-1] / (Const.KBoltzmann * T))
             dfjk[j] = -j * fjk[j] / ne
 
             Uk = Ukp1
@@ -254,15 +342,15 @@ class Element:
         dfjk = (dfjk - fjk * sumDf) / sumF
         return fjk, dfjk
 
-    def fj(self, atmos):
+    def fj(self, atmos: 'Atmosphere') -> Tuple[np.ndarray, np.ndarray]:
         Nspace: int = atmos.depthScale.shape[0]
         T = atmos.temperature
         ne = atmos.ne
 
         C1 = (Const.HPlanck / (2.0 * np.pi * Const.MElectron)) * Const.HPlanck / Const.KBoltzmann
-        
+
         CtNe = 2.0 * (C1/T)**(-1.5) / ne
-        Nstage: int = self.ionpot.shape[0]
+        Nstage: int = self.ionPot.shape[0]
         fj = np.zeros((Nstage, Nspace))
         fj[0, :] = 1.0
         dfj = np.zeros((Nstage, Nspace))
@@ -275,39 +363,7 @@ class Element:
         for j in range(1, Nstage):
             Ukp1 = np.interp(T, self.Tpf, self.pf[j, 0])
 
-            fj[j] = fj[j-1] * CtNe * np.exp(Ukp1 - Uk - self.ionpot[j-1] / (Const.KBoltzmann * T))
-            dfj[j] = -j * fj[j] / ne
-
-            Uk[:] = Ukp1
-
-        sumF = np.sum(fj, axis=0)
-        sumDf = np.sum(dfj, axis=0)
-        fj /= sumF
-        dfj = (dfj - fj * sumDf) / sumF
-        return fj, dfj
-
-    def fj_new(self, temperature, ne, mask=None):
-        Nspace: int = temperature.shape[0]
-        T = temperature
-        ne = ne
-
-        C1 = (Const.HPlanck / (2.0 * np.pi * Const.MElectron)) * Const.HPlanck / Const.KBoltzmann
-        
-        CtNe = 2.0 * (C1/T)**(-1.5) / ne
-        Nstage: int = self.ionpot.shape[0]
-        fj = np.zeros((Nstage, Nspace))
-        fj[0, :] = 1.0
-        dfj = np.zeros((Nstage, Nspace))
-
-        # fjk: fractional population of stage j, at atmospheric index k
-        # The first stage starts with a "population" of 1, then via Saha we compute the relative populations of the other stages, before dividing by the sum across these
-
-        Uk = np.interp(T, self.Tpf, self.pf[0, :])
-
-        for j in range(1, Nstage):
-            Ukp1 = np.interp(T, self.Tpf, self.pf[j, 0])
-
-            fj[j] = fj[j-1] * CtNe * np.exp(Ukp1 - Uk - self.ionpot[j-1] / (Const.KBoltzmann * T))
+            fj[j] = fj[j-1] * CtNe * np.exp(Ukp1 - Uk - self.ionPot[j-1] / (Const.KBoltzmann * T))
             dfj[j] = -j * fj[j] / ne
 
             Uk[:] = Ukp1
@@ -319,54 +375,19 @@ class Element:
         return fj, dfj
 
 
-@dataclass
-class LtePopulations:
-    atomicTable: 'AtomicTable'
-    atmosphere: 'Atmosphere'
-    populations: List[np.ndarray]
-
-    def __getitem__(self, name: str) -> np.ndarray:
-        name = name.upper()
-        if len(name) == 1:
-            name += ' '
-        return self.populations[self.atomicTable.indices[name]]
-    
-
-class AtomicTable:
-    def __init__(self, kuruczPfPath: Optional[str]=None, metallicity: float=0.0, 
-                        abundances: Dict=None, abundDex: bool=True):
-        if set(AtomicWeights.keys()) != set(AtomicAbundances.keys()):
-            raise ValueError('AtomicWeights and AtomicAbundances keys differ (Problem keys: %s)' % repr(set(AtomicWeights.keys()) - set(AtomicAbundances.keys())))
-
-        self.indices = OrderedDict(zip(AtomicWeights.keys(), range(len(AtomicWeights))))
-
-        # Convert abundances and overwrite any provided secondary abundances
-        self.abund = deepcopy(AtomicAbundances)
-        if self.abund['H '] == 12.0:
-            for k, v in self.abund.items():
-                self.abund[k] = 10**(v - 12.0)
-
-        if abundances is not None:
-            if abundDex:
-                for k, v in abundances.items():
-                    abundances[k] = 10**(v - 12.0)
-            for k, v in abundances.items():
-                self.abund[k] = v
-
-        metallicity = 10**metallicity
-        for k, v in self.abund.items():
-            if k != 'H ':
-                self.abund[k] = v*metallicity
-
-
-        # TODO(cmo): replace this with a proper default path
+class KuruczPfTable:
+    def __init__(self, atomicAbundance=None):
+        if atomicAbundance is None:
+            atomicAbundance = DefaultAtomicAbundance
+        self.atomicAbundance = atomicAbundance
+        # TODO(cmo): replace this with a proper default path:
         kuruczPfPath = get_data_path() + 'pf_Kurucz.input' if kuruczPfPath is None else kuruczPfPath
         with open(kuruczPfPath, 'rb') as f:
             s = f.read()
         u = Unpacker(s)
 
+        # NOTE(cmo): Each of these terms is simply in flat lists indexed by Atomic Number Z-1
         self.Tpf = np.array(u.unpack_array(u.unpack_double))
-        ptIndex = [] # Index in the periodic table (fortran based, so +1) -- could be used for validation
         stages = []
         pf = []
         ionpot = []
@@ -378,135 +399,12 @@ class AtomicTable:
 
         ionpot = [i * Const.HC / Const.CM_TO_M for i in ionpot]
         pf = [np.log(p) for p in pf]
+        self.pf = pf
+        self.ionpot = ionpot
 
-        totalAbund = 0.0
-        avgWeight = 0.0
-        self.elements: List[Element] = []
-        for k, v in AtomicWeights.items():
-            i = self.indices[k]
-            ele = Element(k, v, self.abund[k], ionpot[i], self.Tpf, pf[i])
-            self.elements.append(ele)
-            totalAbund += ele.abundance
-            avgWeight += ele.abundance * ele.weight
+    def __getitem__(self, x: Element) -> KuruczPf:
+        if type(x) is Isotope:
+            raise ValueError('Isotopes not supported by KuruczPf')
 
-        self.totalAbundance = totalAbund
-        self.weightPerH = avgWeight
-        self.avgMolWeight = avgWeight / totalAbund
-
-    def __getitem__(self, name: str) -> Element:
-        name = name.upper()
-        if len(name) == 1:
-            name += ' '
-        return self.elements[self.indices[name]]
-
-    def lte_populations(self, atmos: 'Atmosphere') -> LtePopulations:
-        pops = []
-        for ele in self.elements:
-            pops.append(ele.lte_populations(atmos))
-
-        return LtePopulations(self, atmos, pops)
-
-    def compute_ne_k(self, atmos, k):
-        # Can add a "fromScratch" where we start with ne=nHii
-        neOld = atmos.ne[k]
-
-        C1 = (Const.HPlanck / (2.0 * np.pi * Const.MElectron)) * (Const.HPlanck / Const.KBoltzmann)
-
-        nIter = 1
-        NmaxIter = 100
-        MaxError = 1e-2
-        while nIter < NmaxIter:
-            # Electrons per H
-            error = neOld / atmos.nHTot[k]
-            total = 0.0
-
-            for i, ele in enumerate(self.elements):
-                # Fractional stage pops and derivate wrt ne
-                fjk, dfjk = ele.fjk(atmos, k)
-
-                if ele.name.startswith('H'):
-                # Add H- effects
-                    PhiHmin = 0.25 * (C1 / atmos.temperature[k])**1.5 \
-                                * np.exp(Const.E_ION_HMIN / (Const.KBoltzmann * atmos.temperature[k]))
-                    error += neOld * fjk[0] * PhiHmin
-                    total -= (fjk[0] + neOld * dfjk[0]) * PhiHmin
-
-                for j in range(1, len(ele.ionpot)):
-                    electronContribution = ele.abundance * j
-                    error -= electronContribution * fjk[j]
-                    total += electronContribution * dfjk[j]
-
-            # Quasi-Newton iteration
-            # atmos.nHTot * total is the sum of the derivative of all of the atomic populations wrt ne, weighted by the ionisation stage
-            # Obviously error tends to 0 as this converges -- we're solving f(x) = 0
-            atmos.ne[k] = neOld - atmos.nHTot[k] * error / (1.0 - atmos.nHTot[k] * total)
-            dne = np.abs((atmos.ne[k] - neOld) / neOld)
-            neOld = atmos.ne[k]
-
-            if dne < MaxError:
-                break
-
-            nIter += 1
-
-        if dne > MaxError:
-            raise ConvergenceError("Electron iteration did not converge at point %d" % k)
-        
-
-    def compute_ne(self, atmos):
-        # Can add a "fromScratch" where we start with ne=nHii
-        neOld = atmos.ne.copy()
-
-        C1 = (Const.HPlanck / (2.0 * np.pi * Const.MElectron)) * (Const.HPlanck / Const.KBoltzmann)
-
-        nIter = 1
-        NmaxIter = 100
-        MaxError = 1e-2
-        while nIter < NmaxIter:
-            # Electrons per H
-            error = neOld / atmos.nHTot
-            total = np.zeros_like(error)
-
-            for i, ele in enumerate(self.elements):
-                # Fractional stage pops and derivate wrt ne
-                fj, dfj = ele.fj(atmos)
-
-                if ele.name.startswith('H'):
-                    # Add H- effects
-                    PhiHmin = 0.25 * (C1 / atmos.temperature)**1.5 \
-                                * np.exp(Const.E_ION_HMIN / (Const.KBoltzmann * atmos.temperature))
-                    error += neOld * fj[0] * PhiHmin
-                    total -= (fj[0] + neOld * dfj[0]) * PhiHmin
-
-                for j in range(1, len(ele.ionpot)):
-                    electronContribution = ele.abundance * j
-                    error -= electronContribution * fj[j]
-                    total += electronContribution * dfj[j]
-
-            # Quasi-Newton iteration
-            # atmos.nHTot * total is the sum of the derivative of all of the atomic populations wrt ne, weighted by the ionisation stage
-            # Obviously error tends to 0 as this converges -- we're solving f(x) = 0
-            # Krylov or somtheing?
-            atmos.ne[:] = neOld - atmos.nHTot * error / (1.0 - atmos.nHTot * total)
-            dne = np.max(np.abs((atmos.ne - neOld) / neOld))
-            neOld[:] = atmos.ne
-
-            if dne < MaxError:
-                break
-
-            nIter += 1
-
-        if dne > MaxError:
-            raise ConvergenceError("Electron iteration did not converge")
-
-_StandardAtomicTable: AtomicTable
-def get_global_atomic_table() -> AtomicTable:
-    global _StandardAtomicTable
-    try:
-        return _StandardAtomicTable
-    except NameError:
-        _StandardAtomicTable = AtomicTable()
-    return _StandardAtomicTable
-
-def set_global_atomic_table(table: AtomicTable):
-    global _StandardAtomicTable
-    _StandardAtomicTable = table
+        zm = x.Z - 1
+        return KuruczPf(element=x, abundance=self.atomicAbundance[x], Tpf=self.Tpf, pf=self.pf[zm], ionPot=self.ionpot[zm])

--- a/lightweaver/atomic_table.py
+++ b/lightweaver/atomic_table.py
@@ -22,8 +22,8 @@ class Element:
         return self.Z == other.Z
 
     def __lt__(self, other):
-        if type(other) is Isotope:
-            return NotImplemented
+        if isinstance(other, Isotope):
+            return self.Z <= other.Z
         return self.Z < other.Z
 
     def __repr__(self):
@@ -54,7 +54,7 @@ class Isotope(Element):
         return False
 
     def __lt__(self, other):
-        if type(other) is Isotope:
+        if isinstance(other, Isotope):
             return (self.Z, self.N) < (other.Z, other.N)
         elif type(other) is Element:
             return self.Z < other.Z
@@ -415,6 +415,7 @@ class KuruczPfTable:
         pf = []
         ionpot = []
         for i in range(99):
+            z = u.unpack_int()
             stages.append(u.unpack_int())
             pf.append(np.array(u.unpack_farray(stages[-1] * self.Tpf.shape[0], u.unpack_double)).reshape(stages[-1], self.Tpf.shape[0]))
             ionpot.append(np.array(u.unpack_farray(stages[-1], u.unpack_double)))

--- a/lightweaver/barklem.py
+++ b/lightweaver/barklem.py
@@ -5,7 +5,7 @@ import numpy as np
 if TYPE_CHECKING:
     from .atomic_model import AtomicLevel, AtomicLine, AtomicModel, determinate, CompositeLevelError
 import string
-from .atomic_table import AtomicTable
+from .atomic_table import PeriodicTable
 from .utils import get_data_path
 from scipy.interpolate import RectBivariateSpline
 from scipy.special import gamma
@@ -28,16 +28,12 @@ class BarklemCrossSectionError(Exception):
     pass
 
 class Barklem:
-    def __init__(self, table: AtomicTable):
-        # Should probably make these static class variables, but also they're tiny
-        # TODO(cmo): Move this to be ResourceReader/Loader based?
-        self.barklem_sp = BarklemTable(get_data_path() + 'Barklem_spdata.dat', (1.0, 1.3))
-        self.barklem_pd = BarklemTable(get_data_path() + 'Barklem_pddata.dat', (1.3, 2.3))
-        self.barklem_df = BarklemTable(get_data_path() + 'Barklem_dfdata.dat', (2.3, 3.3))
+    barklem_sp = BarklemTable(get_data_path() + 'Barklem_spdata.dat', (1.0, 1.3))
+    barklem_pd = BarklemTable(get_data_path() + 'Barklem_pddata.dat', (1.3, 2.3))
+    barklem_df = BarklemTable(get_data_path() + 'Barklem_dfdata.dat', (2.3, 3.3))
 
-        self.atomicTable = table
-
-    def get_active_cross_section(self, atom: 'AtomicModel', line: 'AtomicLine') -> Sequence[float]:
+    @classmethod
+    def get_active_cross_section(cls, atom: AtomicModel, line: AtomicLine, vals: Sequence[float]) -> Sequence[float]:
         i = line.i
         j = line.j
 
@@ -46,9 +42,11 @@ class Barklem:
         DOrbit = 2
         FOrbit = 3
 
+        result = [0.0, 0.0, 0.0]
+
         # Follows original RH version. Interpolate tables if sigma < 20.0, otherwise
         # assume the provided values are the coefficients
-        if line.vdw.vals[0] < 20.0:
+        if vals[0] < 20.0:
             if atom.levels[i].stage > 0:
                 raise BarklemCrossSectionError()
 
@@ -67,11 +65,11 @@ class Barklem:
 
             # Check is a Barklem case applies
             if nums == (SOrbit, POrbit) or nums == (POrbit, SOrbit):
-                table = self.barklem_sp
+                table = cls.barklem_sp
             elif nums == (POrbit, DOrbit) or nums == (DOrbit, POrbit):
-                table = self.barklem_pd
+                table = cls.barklem_pd
             elif nums == (DOrbit, FOrbit) or nums == (FOrbit, DOrbit):
-                table = self.barklem_df
+                table = cls.barklem_df
             else:
                 raise BarklemCrossSectionError()
 
@@ -85,7 +83,7 @@ class Barklem:
 
             deltaEi = (atom.levels[ic].E - atom.levels[i].E) * Const.HC / Const.CM_TO_M
             deltaEj = (atom.levels[ic].E - atom.levels[j].E) * Const.HC / Const.CM_TO_M
-            E_Rydberg = Const.ERydberg / (1.0 + Const.MElectron / (self.atomicTable[atom.name].weight * Const.Amu))
+            E_Rydberg = Const.ERydberg / (1.0 + Const.MElectron / (atom.element.mass * Const.Amu))
 
             neff1 = Z * np.sqrt(E_Rydberg / deltaEi)
             neff2 = Z * np.sqrt(E_Rydberg / deltaEj)
@@ -99,21 +97,19 @@ class Barklem:
                 raise BarklemCrossSectionError()
 
 
-            vals = np.zeros(4)
-            vals[0] = RectBivariateSpline(table.neff1, table.neff2, table.cross)(neff1, neff2)
-            vals[1] = RectBivariateSpline(table.neff1, table.neff2, table.alpha)(neff1, neff2)
+            result[0] = RectBivariateSpline(table.neff1, table.neff2, table.cross)(neff1, neff2)
+            result[1] = RectBivariateSpline(table.neff1, table.neff2, table.alpha)(neff1, neff2)
 
-        reducedMass = Const.Amu / (1.0 / self.atomicTable['H'].weight + 1.0 / self.atomicTable[atom.name].weight)
+        reducedMass = Const.Amu / (1.0 / PeriodicTable[1].mass + 1.0 / atom.element.mass)
         meanVel = np.sqrt(8.0 * Const.KBoltzmann / (np.pi * reducedMass))
         meanCross = Const.RBohr**2 * (meanVel / 1.0e4)**(-vals[1])
 
-        vals[0] *= 2.0 * (4.0 / np.pi)**(vals[1]/2.0) * gamma(4.0 - vals[1] / 2.0) * meanVel * meanCross
+        result[0] = vals[0] * 2.0 * (4.0 / np.pi)**(vals[1]/2.0) * gamma(4.0 - vals[1] / 2.0) * meanVel * meanCross
 
         # Use Unsold for Helium contribution
-        vals[2] = 1.0
-        # vals[3] = 0.0
+        result[2] = 1.0
 
-        return vals
+        return result
 
 
-    
+

--- a/lightweaver/broadening.py
+++ b/lightweaver/broadening.py
@@ -1,0 +1,307 @@
+from dataclasses import dataclass, field
+from typing import Sequence, List, Optional, cast, TYPE_CHECKING
+import lightweaver.constants as Const
+import numpy as np
+from .atomic_table import PeriodicTable
+from .barklem import Barklem
+
+if TYPE_CHECKING:
+    from .atomic_model import AtomicLine
+    from .atmosphere import Atmosphere
+    from .atomic_set import SpeciesStateTable
+
+@dataclass
+class LineBroadener:
+    def __repr__(self):
+        raise NotImplementedError
+
+    def setup(self, line: 'AtomicLine'):
+        pass
+
+    def broaden(self, atmos: Atmosphere, eqPops: SpeciesStateTable) -> np.ndarray:
+        raise NotImplementedError
+
+
+@dataclass
+class LineBroadeningResult:
+    Qinelast: np.ndarray
+    Qelast: np.ndarray
+
+
+@dataclass
+class LineBroadening:
+    inelastic: List[LineBroadener]
+    elastic: List[LineBroadener]
+
+    def __repr__(self):
+        s = 'LineBroadening(inelastic=%s, elastic=%s)' % (repr(self.inelastic), repr(self.elastic))
+        return s
+
+    def __post_init__(self):
+        if len(self.inelastic) == 0 and len(self.elastic) == 0:
+            raise ValueError('No broadening terms provided to LineBroadening')
+
+    def setup(self, line: 'AtomicLine'):
+        for b in self.inelastic:
+            b.setup(line)
+
+        for b in self.elastic:
+            b.setup(line)
+
+    @staticmethod
+    def sum_broadening_list(broadeners: List[LineBroadener], atmos: Atmosphere,
+                            eqPops: SpeciesStateTable) -> Optional[np.ndarray]:
+        if len(broadeners) == 0:
+            return None
+
+        result = broadeners[0].broaden(atmos, eqPops)
+        for b in broadeners[1:]:
+            result += b.broaden(atmos, eqPops)
+        return result
+
+    def broaden(self, atmos: Atmosphere, eqPops: SpeciesStateTable) -> LineBroadeningResult:
+        Qinelast = self.sum_broadening_list(self.inelastic, atmos, eqPops)
+        Qelast = self.sum_broadening_list(self.elastic, atmos, eqPops)
+
+        if Qinelast is None:
+            Qinelast = np.zeros_like(Qelast)
+        elif Qelast is None:
+            Qelast = np.zeros_like(Qinelast)
+
+        return LineBroadeningResult(Qinelast=Qinelast, Qelast=Qelast)
+
+
+@dataclass(eq=False)
+class VdwApprox(LineBroadener):
+    vals: Sequence[float]
+    line: AtomicLine = field(init=False)
+
+    def setup(self, line: AtomicLine):
+        self.line = line
+
+    def __repr__(self):
+        s = '%s(vals=%s)' % (type(self).__name__, repr(self.vals))
+        return s
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+
+        if self.vals != other.vals:
+            return False
+
+        try:
+            if self.line != other.line:
+                return False
+        except:
+            pass
+
+        return True
+
+
+@dataclass(eq=False)
+class VdwUnsold(VdwApprox):
+    def setup(self, line: AtomicLine):
+        self.line = line
+        if len(self.vals) != 2:
+            raise ValueError('VdwUnsold expects 2 coefficients (%s)' % repr(line))
+
+        Z = line.jLevel.stage + 1
+        cont = line.overlyingContinuumLevel
+
+        deltaR = (Const.ERydberg / (cont.E_SI - line.jLevel.E_SI))**2 \
+                 - (Const.ERydberg / (cont.E_SI - line.iLevel.E_SI))**2
+        fourPiEps0 = 4.0 * np.pi * Const.Epsilon0
+        self.C625 = (2.5 * Const.QElectron**2 / fourPiEps0 * Const.ABarH / fourPiEps0 \
+                     * 2 * np.pi * (Z * Const.RBohr)**2 / Const.HPlanck * deltaR)**0.4
+
+        element = line.atom.element
+
+        self.vRel35He = (8.0 * Const.KBoltzmann / (np.pi*Const.Amu * element.mass)\
+                         * (1.0 + element.mass / PeriodicTable[2].mass))**0.3
+        self.vRel35H = (8.0 * Const.KBoltzmann / (np.pi*Const.Amu * element.mass)\
+                         * (1.0 + element.mass / PeriodicTable[1].mass))**0.3
+
+
+    def broaden(self, atmos: Atmosphere, eqPops: SpeciesStateTable) -> np.ndarray:
+        heAbund = eqPops.abundance[PeriodicTable[2]]
+        cross = 8.08 * (self.vals[0] * self.vRel35H \
+                             + self.vals[1] * heAbund * self.vRel35He) * self.C625
+        nHGround = eqPops['H'][0, :]
+        broad = cross * atmos.temperature**0.3 * nHGround
+        return broad
+
+
+@dataclass(eq=False)
+class VdwBarklem(VdwApprox):
+    def setup(self, line: AtomicLine):
+        self.line = line
+        if len(self.vals) != 2:
+            raise ValueError('VdwBarklem expects 2 coefficients (%s)' % (repr(line)))
+        newVals = Barklem.get_active_cross_section(line.atom, line, self.vals)
+
+        self.barklemVals = newVals
+
+        Z = line.jLevel.stage + 1
+        cont = line.overlyingContinuumLevel
+
+        deltaR = (Const.ERydberg / (cont.E_SI - line.jLevel.E_SI))**2 \
+                 - (Const.ERydberg / (cont.E_SI - line.iLevel.E_SI))**2
+        fourPiEps0 = 4.0 * np.pi * Const.Epsilon0
+        self.C625 = (2.5 * Const.QElectron**2 / fourPiEps0 * Const.ABarH / fourPiEps0 \
+                     * 2 * np.pi * (Z * Const.RBohr)**2 / Const.HPlanck * deltaR)**0.4
+
+        element = line.atom.element
+
+        self.vRel35He = (8.0 * Const.KBoltzmann / (np.pi*Const.Amu * element.mass)\
+                         * (1.0 + element.mass / PeriodicTable[2].mass))**0.3
+
+
+    def broaden(self, atmos: Atmosphere, eqPops: SpeciesStateTable) -> np.ndarray:
+        heAbund = eqPops.abundance[PeriodicTable[2]]
+        nHGround = eqPops['H'][0, :]
+        cross = 8.08 * self.barklemVals[2] * heAbund * self.vRel35He * self.C625
+
+        broad = self.barklemVals[0] * atmos.temperature**(0.5*(1.0-self.barklemVals[1])) \
+                 + cross * atmos.temperature**0.3
+        broad *= nHGround
+        return broad
+
+
+@dataclass(eq=False)
+class RadiativeBroadening(LineBroadener):
+    gamma: float
+    line: AtomicLine = field(init=False)
+
+    def setup(self, line: AtomicLine):
+        self.line = line
+
+    def __repr__(self):
+        s = 'RadiativeBroadening(gamma=%.4e)' % self.gamma
+        return s
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+
+        if self.gamma != other.gamma:
+            return False
+
+        try:
+            if self.line != other.line:
+                return False
+        except:
+            pass
+
+        return True
+
+    def broaden(self, atmos: Atmosphere, eqPops: SpeciesStateTable) -> np.ndarray:
+        return np.ones_like(atmos.temperature) * self.gamma
+
+@dataclass
+class QuadraticStarkBroaden(LineBroadener):
+    coeff: float
+    line: AtomicLine = field(init=False)
+
+    def __repr__(self):
+        s = 'QuadraticStarkBroaden(coeff=%.4e)' % self.coeff
+        return s
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+
+        if self.coeff != other.coeff:
+            return False
+
+        try:
+            if self.line != other.line:
+                return False
+        except:
+            pass
+
+        return True
+
+    def setup(self, line: AtomicLine):
+        self.line = line
+        weight = line.atom.element.mass
+        C = 8.0 * Const.KBoltzmann / (np.pi * Const.Amu * weight)
+        Cm = (1.0 + weight / (Const.MElectron / Const.Amu))**(1.0/6.0)
+        # NOTE(cmo): 28.0 is average atomic weight
+        Cm += (1.0 + weight / (28.0))**(1.0/6.0)
+        self.C = C
+        self.Cm = Cm
+
+        Z = line.iLevel.stage + 1
+        cont = line.overlyingContinuumLevel
+
+        E_Ryd = Const.ERydberg / (1.0 + Const.MElectron / (weight * Const.Amu))
+        neff_l = Z * np.sqrt(E_Ryd / (cont.E_SI - line.iLevel.E_SI))
+        neff_u = Z * np.sqrt(E_Ryd / (cont.E_SI - line.jLevel.E_SI))
+
+        C4 = Const.QElectron**2 / (4.0 * np.pi * Const.Epsilon0) \
+            * Const.RBohr \
+            * (2.0 * np.pi * Const.RBohr**2 / Const.HPlanck) / (18.0 * Z**4) \
+            * ((neff_u * (5.0 * neff_u**2 + 1.0))**2 \
+                - (neff_l * (5.0 * neff_l**2 + 1.0))**2)
+        self.cStark23 = 11.37 * (self.coeff * C4)**(2.0/3.0)
+
+    def broaden(self, atmos: Atmosphere, eqPops: SpeciesStateTable) -> np.ndarray:
+        vRel = (self.C * atmos.temperature)**(1.0/6.0) * self.Cm
+        stark = self.cStark23 * vRel * atmos.ne
+        return stark
+
+@dataclass
+class MultiplicativeStarkBroaden(LineBroadener):
+    coeff: float
+
+    def __repr__(self):
+        s = 'MultiplicativeStarkBroaden(coeff=%.4e)' % self.coeff
+        return s
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+
+        if self.coeff != other.coeff:
+            return False
+
+        return True
+
+    def broaden(self, atmos: Atmosphere, eqPops: SpeciesStateTable) -> np.ndarray:
+        return self.coeff * atmos.ne # type: ignore
+
+@dataclass
+class HydrogenLinearStarkBroaden(LineBroadener):
+    line: AtomicLine = field(init=False)
+
+    def __repr__(self):
+        s = 'HydrogenLinearStarkBroaden()'
+        return s
+
+    def __eq__(self, other):
+        if type(self) is not type(other):
+            return False
+
+        try:
+            if self.line != other.line:
+                return False
+        except:
+            pass
+
+        return True
+
+    def setup(self, line: AtomicLine):
+        self.line = line
+
+        if line.atom.element.Z != 1:
+            raise ValueError('HydrogenicLinearStarkBroaden applied to non-Hydrogen line')
+
+    def broaden(self, atmos: Atmosphere, eqPops: SpeciesStateTable) -> np.ndarray:
+        nUpper = int(np.round(np.sqrt(0.5*self.line.jLevel.g)))
+        nLower = int(np.round(np.sqrt(0.5*self.line.iLevel.g)))
+
+        a1 = 0.642 if nUpper - nLower == 1 else 1.0
+        C = a1 * 0.6 * (nUpper**2 - nLower**2) * Const.CM_TO_M**2
+        GStark = C * atmos.ne**(2.0/3.0)
+        return GStark

--- a/lightweaver/collisional_rates.py
+++ b/lightweaver/collisional_rates.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class CollisionalRates:
     j: int
     i: int
-    atom: AtomicModel = field(init=False)
+    atom: 'AtomicModel' = field(init=False)
 
     def __repr__(self):
         s = 'CollisionalRates(j=%d, i=%d)' % (self.j, self.i)
@@ -26,7 +26,7 @@ class CollisionalRates:
     def setup(self, atom):
         pass
 
-    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+    def compute_rates(self, atmos: 'Atmosphere', eqPops: 'SpeciesStateTable', Cmat: np.ndarray):
         raise NotImplementedError
 
     def __eq__(self, other: object) -> bool:
@@ -54,7 +54,7 @@ class Omega(TemperatureInterpolationRates):
         self.iLevel = atom.levels[self.i]
         self.C0 = Const.ERydberg / np.sqrt(Const.MElectron) * np.pi * Const.RBohr**2 * np.sqrt(8.0 / (np.pi * Const.KBoltzmann))
 
-    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+    def compute_rates(self, atmos: 'Atmosphere', eqPops: 'SpeciesStateTable', Cmat: np.ndarray):
         C = weno4(atmos.temperature, self.temperature, self.rates)
         C[C < 0.0] = 0.0
         nstar = eqPops.atomicPops[self.atom.element].nStar
@@ -77,7 +77,7 @@ class CI(TemperatureInterpolationRates):
         self.iLevel = atom.levels[self.i]
         self.dE = self.jLevel.E_SI - self.iLevel.E_SI
 
-    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+    def compute_rates(self, atmos: 'Atmosphere', eqPops: 'SpeciesStateTable', Cmat: np.ndarray):
         C = weno4(atmos.temperature, self.temperature, self.rates)
         C[C < 0.0] = 0.0
         nstar = eqPops.atomicPops[self.atom.element].nStar
@@ -101,7 +101,7 @@ class CE(TemperatureInterpolationRates):
         self.iLevel = atom.levels[self.i]
         self.gij = self.iLevel.g / self.jLevel.g
 
-    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+    def compute_rates(self, atmos: 'Atmosphere', eqPops: 'SpeciesStateTable', Cmat: np.ndarray):
         C = weno4(atmos.temperature, self.temperature, self.rates)
         C[C < 0.0] = 0.0
         nstar = eqPops.atomicPops[self.atom.element].nStar
@@ -182,7 +182,7 @@ class Ar85Cdi(CollisionalRates):
         self.jLevel = atom.levels[self.j]
         self.cdi = np.array(self.cdi)
 
-    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+    def compute_rates(self, atmos: 'Atmosphere', eqPops: 'SpeciesStateTable', Cmat: np.ndarray):
         nstar = eqPops.atomicPops[self.atom.element].nStar
         Cup = np.zeros(atmos.Nspace)
         cdi = cast(np.ndarray, self.cdi)
@@ -207,7 +207,7 @@ class Burgess(CollisionalRates):
     fudge: float = 1.0
 
     def __repr__(self):
-        s = 'Burgess(j=%d, i=%d, fudge=%e)' % (self.j, self.i, self.fudge)
+        s = 'Burgess(j=%d, i=%d, fudge=%g)' % (self.j, self.i, self.fudge)
         return s
 
     def setup(self, atom):
@@ -218,7 +218,7 @@ class Burgess(CollisionalRates):
         self.iLevel = atom.levels[self.i]
         self.jLevel = atom.levels[self.j]
 
-    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+    def compute_rates(self, atmos: 'Atmosphere', eqPops: 'SpeciesStateTable', Cmat: np.ndarray):
         nstar = eqPops.atomicPops[self.atom.element].nStar
         dE = (self.jLevel.E_SI - self.iLevel.E_SI) / Const.EV
         zz = self.iLevel.stage

--- a/lightweaver/collisional_rates.py
+++ b/lightweaver/collisional_rates.py
@@ -1,27 +1,48 @@
-from .atomic_model import CollisionalRates, AtomicModel
+from .atomic_model import model_component_eq
+from .utils import sequence_repr
 import lightweaver.constants as Const
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import numpy as np
-from typing import Sequence
+from typing import Sequence, cast, TYPE_CHECKING
 from scipy.special import exp1
 from numba import njit
-from scipy.interpolate import interp1d
+from weno4 import weno4
+
+if TYPE_CHECKING:
+    from .atomic_model import AtomicModel
+    from .atmosphere import Atmosphere
+    from .atomic_set import SpeciesStateTable
+
+@dataclass
+class CollisionalRates:
+    j: int
+    i: int
+    atom: AtomicModel = field(init=False)
+
+    def __repr__(self):
+        s = 'CollisionalRates(j=%d, i=%d)' % (self.j, self.i)
+        return s
+
+    def setup(self, atom):
+        pass
+
+    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+        raise NotImplementedError
+
+    def __eq__(self, other: object) -> bool:
+        return model_component_eq(self, other)
+
 
 @dataclass(eq=False)
 class TemperatureInterpolationRates(CollisionalRates):
     temperature: Sequence[float]
     rates: Sequence[float]
 
-    def setup_interpolator(self):
-        if len(self.rates) <  3:
-            self.interpolator = interp1d(self.temperature, self.rates, fill_value=(self.rates[0], self.rates[-1]), bounds_error=False)
-        else:
-            self.interpolator = interp1d(self.temperature, self.rates, kind=3, fill_value=(self.rates[0], self.rates[-1]), bounds_error=False)
 
 @dataclass(eq=False)
 class Omega(TemperatureInterpolationRates):
     def __repr__(self):
-        s = 'Omega(j=%d, i=%d, temperature=%s, rates=%s)' % (self.j, self.i, repr(self.temperature), repr(self.rates))
+        s = 'Omega(j=%d, i=%d, temperature=%s, rates=%s)' % (self.j, self.i, sequence_repr(self.temperature), sequence_repr(self.rates))
         return s
 
     def setup(self, atom):
@@ -33,13 +54,10 @@ class Omega(TemperatureInterpolationRates):
         self.iLevel = atom.levels[self.i]
         self.C0 = Const.ERydberg / np.sqrt(Const.MElectron) * np.pi * Const.RBohr**2 * np.sqrt(8.0 / (np.pi * Const.KBoltzmann))
 
-    def compute_rates(self, atmos, nstar, Cmat):
-        try:
-            C = self.interpolator(atmos.temperature)
-        except AttributeError:
-            self.setup_interpolator()
-            C = self.interpolator(atmos.temperature)
-
+    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+        C = weno4(atmos.temperature, self.temperature, self.rates)
+        C[C < 0.0] = 0.0
+        nstar = eqPops.atomicPops[self.atom.element].nStar
         Cdown = self.C0 * atmos.ne * C / (self.jLevel.g * np.sqrt(atmos.temperature))
         Cmat[self.i, self.j, :] += Cdown
         Cmat[self.j, self.i, :] += Cdown * nstar[self.j] / nstar[self.i]
@@ -47,7 +65,7 @@ class Omega(TemperatureInterpolationRates):
 @dataclass(eq=False)
 class CI(TemperatureInterpolationRates):
     def __repr__(self):
-        s = 'CI(j=%d, i=%d, temperature=%s, rates=%s)' % (self.j, self.i, repr(self.temperature), repr(self.rates))
+        s = 'CI(j=%d, i=%d, temperature=%s, rates=%s)' % (self.j, self.i, sequence_repr(self.temperature), sequence_repr(self.rates))
         return s
 
     def setup(self, atom):
@@ -59,12 +77,10 @@ class CI(TemperatureInterpolationRates):
         self.iLevel = atom.levels[self.i]
         self.dE = self.jLevel.E_SI - self.iLevel.E_SI
 
-    def compute_rates(self, atmos, nstar, Cmat):
-        try:
-            C = self.interpolator(atmos.temperature)
-        except AttributeError:
-            self.setup_interpolator()
-            C = self.interpolator(atmos.temperature)
+    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+        C = weno4(atmos.temperature, self.temperature, self.rates)
+        C[C < 0.0] = 0.0
+        nstar = eqPops.atomicPops[self.atom.element].nStar
         Cup = C * atmos.ne * np.exp(-self.dE / (Const.KBoltzmann * atmos.temperature)) * np.sqrt(atmos.temperature)
         Cmat[self.j, self.i, :] += Cup
         Cmat[self.i, self.j, :] += Cup * nstar[self.i] / nstar[self.j]
@@ -85,12 +101,10 @@ class CE(TemperatureInterpolationRates):
         self.iLevel = atom.levels[self.i]
         self.gij = self.iLevel.g / self.jLevel.g
 
-    def compute_rates(self, atmos, nstar, Cmat):
-        try:
-            C = self.interpolator(atmos.temperature)
-        except AttributeError:
-            self.setup_interpolator()
-            C = self.interpolator(atmos.temperature)
+    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+        C = weno4(atmos.temperature, self.temperature, self.rates)
+        C[C < 0.0] = 0.0
+        nstar = eqPops.atomicPops[self.atom.element].nStar
         Cdown = C * atmos.ne * self.gij * np.sqrt(atmos.temperature)
         Cmat[self.i, self.j, :] += Cdown
         Cmat[self.j, self.i, :] += Cdown * nstar[self.j] / nstar[self.i]
@@ -156,12 +170,7 @@ class Ar85Cdi(CollisionalRates):
     cdi: Sequence[Sequence[float]]
 
     def __repr__(self):
-        if type(self.cdi) is np.ndarray:
-            cdi = repr(self.cdi.tolist())
-        else:
-            cdi = repr(self.cdi)
-
-        s = 'Ar85Cdi(j=%d, i=%d, cdi=%s)' % (self.j, self.i, cdi)
+        s = 'Ar85Cdi(j=%d, i=%d, cdi=%s)' % (self.j, self.i, sequence_repr(self.cdi))
         return s
 
     def setup(self, atom):
@@ -173,15 +182,17 @@ class Ar85Cdi(CollisionalRates):
         self.jLevel = atom.levels[self.j]
         self.cdi = np.array(self.cdi)
 
-    def compute_rates(self, atmos, nstar, Cmat):
+    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+        nstar = eqPops.atomicPops[self.atom.element].nStar
         Cup = np.zeros(atmos.Nspace)
-        for m in range(self.cdi.shape[0]):
-            xj = self.cdi[m, 0] * Const.EV / (Const.KBoltzmann * atmos.temperature)
+        cdi = cast(np.ndarray, self.cdi)
+        for m in range(cdi.shape[0]):
+            xj = cdi[m, 0] * Const.EV / (Const.KBoltzmann * atmos.temperature)
             fac = np.exp(-xj) * np.sqrt(xj)
-            fxj = self.cdi[m, 1] + self.cdi[m, 2] * (1.0 + xj) + (self.cdi[m, 3] - xj * (self.cdi[m, 1] + self.cdi[m, 2] * (2.0 + xj))) * fone(xj) + self.cdi[m, 4] * xj * ftwo(xj)
+            fxj = cdi[m, 1] + cdi[m, 2] * (1.0 + xj) + (cdi[m, 3] - xj * (cdi[m, 1] + cdi[m, 2] * (2.0 + xj))) * fone(xj) + cdi[m, 4] * xj * ftwo(xj)
 
             fxj *= fac
-            fac = 6.69e-7 / self.cdi[m, 0]**1.5
+            fac = 6.69e-7 / cdi[m, 0]**1.5
             Cup += fac * fxj * Const.CM_TO_M**3
         Cup[Cup < 0] = 0.0
 
@@ -207,7 +218,8 @@ class Burgess(CollisionalRates):
         self.iLevel = atom.levels[self.i]
         self.jLevel = atom.levels[self.j]
 
-    def compute_rates(self, atmos, nstar, Cmat):
+    def compute_rates(self, atmos: Atmosphere, eqPops: SpeciesStateTable, Cmat: np.ndarray):
+        nstar = eqPops.atomicPops[self.atom.element].nStar
         dE = (self.jLevel.E_SI - self.iLevel.E_SI) / Const.EV
         zz = self.iLevel.stage
         betaB = 0.25 * (np.sqrt((100.0 * zz + 91.0) / (4.0 * zz + 3.0)) - 5.0)

--- a/lightweaver/molecule.py
+++ b/lightweaver/molecule.py
@@ -1,7 +1,7 @@
 from parse import parse
 import lightweaver.constants as Const
-from typing import Tuple, Set, List, TYPE_CHECKING, Optional
-from .atomic_table import AtomicTable, Element, get_global_atomic_table
+from typing import Tuple, Set, List, TYPE_CHECKING, Optional, Union
+from .atomic_table import PeriodicTable, Element
 from .atmosphere import Atmosphere
 import numpy as np
 from numpy.linalg import solve
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from collections import OrderedDict
 
 # TODO(cmo): This should really be done with a generator/coroutine
-def get_next_line(data):
+def get_next_line(data: List[str]) -> Optional[str]:
     if len(data) == 0:
         return None
     for i, d in enumerate(data):
@@ -100,7 +100,7 @@ def equilibrium_constant_sauval_tatum(tempRange, Ediss, eqc):
 
 
 class Molecule:
-    def __init__(self, filePath: str, atomicTable: AtomicTable):
+    def __init__(self, filePath: str):
         with open(filePath, 'r') as f:
             lines = f.readlines()
 
@@ -113,7 +113,7 @@ class Molecule:
 
         structure = get_next_line(lines)
         constituents = [get_constituent(s.strip()) for s in structure.split(',')]
-        self.elements = [atomicTable[c[1]] for c in constituents]
+        self.elements = [PeriodicTable[c[1]] for c in constituents]
         self.elementCount = [c[0] for c in constituents]
         self.Nnuclei = sum(self.elementCount)
 
@@ -139,7 +139,7 @@ class Molecule:
 
         self.weight = 0.0
         for count, ele in zip(self.elementCount, self.elements):
-            self.weight += count * ele.weight
+            self.weight += count * ele.mass
 
         if fitStr == 'KURUCZ_70':
             self.equilibrium_constant = equilibrium_constant_kurucz_70(self.formationTempRange,
@@ -154,17 +154,15 @@ class Molecule:
             raise ValueError('Unknown molecular equilibrium constant fit method %s in molecule %s' % (fitStr, self.name))
 
 class MolecularTable:
-    def __init__(self, paths: Optional[List[str]]=None, table: Optional[AtomicTable]=None):
-        if table is None:
-            table = get_global_atomic_table()
-        self.molecules: List[Molecule] = []
+    def __init__(self, paths: Optional[List[str]]=None):
 
+        self.molecules: List[Molecule] = []
         if paths is None:
             self.indices = OrderedDict()
             return
 
         for path in paths:
-            self.molecules.append(Molecule(path, table))
+            self.molecules.append(Molecule(path))
 
         self.indices = OrderedDict(zip([m.name for m in self.molecules], list(range(len(self.molecules)))))
 
@@ -172,8 +170,11 @@ class MolecularTable:
         name = name.upper()
         return self.molecules[self.indices[name]]
 
-    def __contains__(self, name: str) -> bool:
-        name = name.upper()
+    def __contains__(self, name: Union[int, Tuple[int, int], str, Element]) -> bool:
+        if type(name) is not str:
+            return False
+
+        name = name.upper() # type: ignore
         return name in self.indices.keys()
 
     def __len__(self) -> int:

--- a/lightweaver/molecule.py
+++ b/lightweaver/molecule.py
@@ -1,7 +1,7 @@
 from parse import parse
 import lightweaver.constants as Const
 from typing import Tuple, Set, List, TYPE_CHECKING, Optional
-from .atomic_table import LtePopulations, AtomicTable, Element, get_global_atomic_table
+from .atomic_table import AtomicTable, Element, get_global_atomic_table
 from .atmosphere import Atmosphere
 import numpy as np
 from numpy.linalg import solve
@@ -90,7 +90,7 @@ def equilibrium_constant_sauval_tatum(tempRange, Ediss, eqc):
         theta = THETA0 / T
         t = np.log10(theta)
         kT = kB * T
-        
+
         eq = eqc[0]
         for i in range(1, eqc.shape[0]):
             eq = eq * t + eqc[i]
@@ -142,11 +142,11 @@ class Molecule:
             self.weight += count * ele.weight
 
         if fitStr == 'KURUCZ_70':
-            self.equilibrium_constant = equilibrium_constant_kurucz_70(self.formationTempRange, 
-             self.Nnuclei - 1 - self.charge, 
+            self.equilibrium_constant = equilibrium_constant_kurucz_70(self.formationTempRange,
+             self.Nnuclei - 1 - self.charge,
              self.Ediss, self.eqcCoeffs)
         elif fitStr == 'KURUCZ_85':
-            self.equilibrium_constant = equilibrium_constant_kurucz_85(self.formationTempRange, 
+            self.equilibrium_constant = equilibrium_constant_kurucz_85(self.formationTempRange,
             self.Nnuclei - 1 - self.charge, self.Ediss, self.eqcCoeffs)
         elif fitStr == 'SAUVAL_TATUM_84':
             self.equilibrium_constant = equilibrium_constant_sauval_tatum(self.formationTempRange, self.Ediss, self.eqcCoeffs)
@@ -197,53 +197,3 @@ class MolecularTableIterator():
             return mol
 
         raise StopIteration
-
-@dataclass
-class EquilibriumPopulations:
-    atmosphere: Atmosphere
-    atomicTable: AtomicTable
-    atomicPops: List[np.ndarray]
-    molecularTable: MolecularTable
-    molecularPops: List[np.ndarray]
-    HminPops: np.ndarray
-
-    def __getitem__(self, name: str) -> np.ndarray:
-        if name == 'H-':
-            return self.HminPops
-        else:
-            name = name.upper()
-            if len(name) == 1:
-                name += ' '
-
-            if name in self.molecularTable.indices.keys():
-                key = self.molecularTable.indices[name]
-                return self.molecularPops[key]
-            elif name in self.atomicTable.indices.keys():
-                key = self.atomicTable.indices[name]
-                return self.atomicPops[key]
-            else:
-                raise KeyError('Unknown key: %s' % name)
-
-    def __contains__(self, name: str) -> bool:
-        if name == 'H-':
-            return True
-        
-        if name in self.molecularTable.indices.keys():
-            return True
-
-        if name in self.atomicTable.indices.keys():
-            return True
-
-        return False
-
-    def atomic_population(self, name: str) -> np.ndarray:
-        name = name.upper()
-        if len(name) == 1:
-            name += ' '
-        key = self.atomicTable.indices[name]
-        return self.atomicPops[key]
-
-    def molecular_population(self, name: str) -> np.ndarray:
-        name = name.upper()
-        key = self.molecularTable.indices[name]
-        return self.molecularPops[key]

--- a/lightweaver/nr_update.py
+++ b/lightweaver/nr_update.py
@@ -55,7 +55,7 @@ def F(self, k, backgroundNe=0.0, atoms=None):
 
 
 def nr_post_update(self, fdCollisionRates=True, hOnly=False, timeDependentData=None):
-    assert self.activeAtoms[0].model.element == PeriodicTable[0]
+    assert self.activeAtoms[0].element == PeriodicTable[1]
     crswVal = self.crswCallback.val
 
     timeDependent = (timeDependentData is not None)
@@ -72,7 +72,7 @@ def nr_post_update(self, fdCollisionRates=True, hOnly=False, timeDependentData=N
 
 
     if hOnly:
-        backgroundAtoms = [model for ele, model in self.arguments['spect'].radSet.items() if ele != PeriodicTable[0]]
+        backgroundAtoms = [model for ele, model in self.arguments['spect'].radSet.items() if ele != PeriodicTable[1]]
     else:
         backgroundAtoms = self.arguments['spect'].radSet.passiveAtoms
 

--- a/lightweaver/nr_update.py
+++ b/lightweaver/nr_update.py
@@ -1,6 +1,7 @@
 import numpy as np
 from .atomic_set import lte_pops
 from scipy.linalg import solve
+from .atomic_table import PeriodicTable
 
 def Ftd(self, k, dt, nPrev, backgroundNe=0.0, atoms=None):
     Nlevel = 0
@@ -11,7 +12,7 @@ def Ftd(self, k, dt, nPrev, backgroundNe=0.0, atoms=None):
         Nlevel += atom.Nlevel
     Neqn = Nlevel + 1
 
-    stages = [np.array([l.stage for l in atom.atomicModel.levels]) 
+    stages = [np.array([l.stage for l in atom.atomicModel.levels])
               for atom in atoms]
 
     F = np.zeros(Neqn)
@@ -37,7 +38,7 @@ def F(self, k, backgroundNe=0.0, atoms=None):
         Nlevel += atom.Nlevel
     Neqn = Nlevel + 1
 
-    stages = [np.array([l.stage for l in atom.atomicModel.levels]) 
+    stages = [np.array([l.stage for l in atom.atomicModel.levels])
               for atom in atoms]
 
     F = np.zeros(Neqn)
@@ -54,7 +55,7 @@ def F(self, k, backgroundNe=0.0, atoms=None):
 
 
 def nr_post_update(self, fdCollisionRates=True, hOnly=False, timeDependentData=None):
-    assert self.activeAtoms[0].atomicModel.name.startswith('H')
+    assert self.activeAtoms[0].model.element == PeriodicTable[0]
     crswVal = self.crswCallback.val
 
     timeDependent = (timeDependentData is not None)
@@ -66,21 +67,21 @@ def nr_post_update(self, fdCollisionRates=True, hOnly=False, timeDependentData=N
     Neqn = Nlevel + 1
 
     Nspace = self.atmos.Nspace
-    stages = [np.array([l.stage for l in atom.atomicModel.levels]) 
+    stages = [np.array([l.stage for l in atom.atomicModel.levels])
               for atom in atoms]
-    
+
 
     if hOnly:
-        backgroundAtoms = self.arguments['spect'].radSet.atoms[1:] 
+        backgroundAtoms = [model for ele, model in self.arguments['spect'].radSet.items() if ele != PeriodicTable[0]]
     else:
         backgroundAtoms = self.arguments['spect'].radSet.passiveAtoms
 
     backgroundNe = np.zeros_like(self.atmos.ne)
     for idx, atomModel in enumerate(backgroundAtoms):
-        lteStages = np.array([l.stage for l in atomModel.levels]) 
-        atom = self.arguments['eqPops'].atomicPops[atomModel.name]
+        lteStages = np.array([l.stage for l in atomModel.levels])
+        atom = self.arguments['eqPops'].atomicPops[atomModel.element]
         backgroundNe += (lteStages[:, None] * atom.n[:, :]).sum(axis=0)
-              
+
     neStart = np.copy(self.atmos.ne)
 
     if fdCollisionRates:
@@ -92,7 +93,7 @@ def nr_post_update(self, fdCollisionRates=True, hOnly=False, timeDependentData=N
             pert = neStart * pertSize
             self.atmos.ne[:] += pert
             nStarPrev = np.copy(atom.nStar)
-            atom.nStar[:] = lte_pops(atom.atomicModel, self.atmos.temperature, 
+            atom.nStar[:] = lte_pops(atom.atomicModel, self.atmos.temperature,
                                      self.atmos.ne, atom.nTotal)
             atom.compute_collisions(fillDiagonal=True)
             self.atmos.ne[:] = neStart
@@ -109,7 +110,7 @@ def nr_post_update(self, fdCollisionRates=True, hOnly=False, timeDependentData=N
     for k in range(Nspace):
         dF[...] = 0.0
         if timeDependent:
-            Fg = self.Ftd(k, dt=timeDependentData['dt'], 
+            Fg = self.Ftd(k, dt=timeDependentData['dt'],
                           nPrev=timeDependentData['nPrev'],
                           backgroundNe=backgroundNe[k], atoms=atoms)
         else:

--- a/lightweaver/utils.py
+++ b/lightweaver/utils.py
@@ -2,7 +2,7 @@ import lightweaver.constants as C
 from copy import copy, deepcopy
 import numpy as np
 import os
-from typing import Tuple
+from typing import Tuple, Sequence
 from dataclasses import dataclass
 from enum import Enum, auto
 from astropy import units
@@ -33,7 +33,7 @@ def planck(temp, wav):
 
 def gaunt_bf(wvl, nEff, charge) -> float:
     # /* --- M. J. Seaton (1960), Rep. Prog. Phys. 23, 313 -- ----------- */
-    # Copied from RH, ensuring vectorisation support 
+    # Copied from RH, ensuring vectorisation support
     x = C.HC / (wvl * C.NM_TO_M) / (C.ERydberg * charge**2)
     x3 = x**(1.0/3.0)
     nsqx = 1.0 / (nEff**2 *x)
@@ -69,7 +69,7 @@ def air_to_vac(wavelength: np.ndarray) -> np.ndarray:
 def convert_specific_intensity(wavelength: np.ndarray, specInt: np.ndarray, outUnits) -> units.quantity.Quantity:
     if not isinstance(wavelength, units.Quantity):
         wavelength = wavelength << units.nm
-    
+
     if not isinstance(specInt, units.Quantity):
         specInt = specInt << units.J / units.s / units.m**2 / units.sr / units.Hz
 
@@ -89,3 +89,9 @@ class UnityCrswIterator(CrswIterator):
 
     def __call__(self):
         return self.val
+
+def sequence_repr(x: Sequence) -> str:
+    if isinstance(x, np.ndarray):
+        return repr(x.tolist())
+
+    return repr(x)

--- a/lightweaver/zeeman.py
+++ b/lightweaver/zeeman.py
@@ -54,7 +54,7 @@ def lande_factor(J: Fraction, L: int, S: Fraction) -> float:
         return 0.0
     return float(1.5 + (S * (S + 1.0) - L * (L + 1)) / (2.0 * J * (J + 1.0)))
 
-def effective_lande(line: AtomicLine):
+def effective_lande(line: 'AtomicLine'):
     if line.gLandeEff is not None:
         return line.gLandeEff
 
@@ -68,7 +68,7 @@ def effective_lande(line: AtomicLine):
     return 0.5 * (gU + gL) + \
            0.25 * (gU - gL) * (j.J * (j.J + 1.0) - i.J * (i.J + 1.0)) # type: ignore
 
-def compute_zeeman_components(line: AtomicLine) -> Optional[ZeemanComponents]:
+def compute_zeeman_components(line: 'AtomicLine') -> Optional[ZeemanComponents]:
     # Just do basic anomalous Zeeman splitting
     if line.gLandeEff is not None:
         alpha = np.array([-1, 0, 1], dtype=np.int32)

--- a/lightweaver/zeeman.py
+++ b/lightweaver/zeeman.py
@@ -1,0 +1,109 @@
+import numpy as np
+from typing import Optional, cast, Iterator, TYPE_CHECKING
+from fractions import Fraction
+from dataclasses import dataclass
+
+if TYPE_CHECKING:
+    from .atomic_model import AtomicLine
+
+def fraction_range(start: Fraction, stop: Fraction, step: Fraction=Fraction(1,1)) -> Iterator[Fraction]:
+    while start < stop:
+        yield start
+        start += step
+
+@dataclass
+class ZeemanComponents:
+    alpha: np.ndarray
+    strength: np.ndarray
+    shift: np.ndarray
+
+def zeeman_strength(Ju: Fraction, Mu: Fraction, Jl: Fraction, Ml: Fraction) -> float:
+    alpha  = int(Ml - Mu)
+    dJ = int(Ju - Jl)
+
+    # These parameters are x2 those in del Toro Iniesta (p. 137), but we normalise after the fact, so it's fine
+
+    if dJ == 0: # jMin = ju = jl
+        if alpha == 0: # pi trainsitions
+            s = 2.0 * Mu**2
+        elif alpha == -1: # sigma_b transitions
+            s = (Ju + Mu) * (Ju - Mu + 1.0)
+        elif alpha == 1: # sigma_r transitions
+            s = (Ju - Mu) * (Ju + Mu + 1.0)
+    elif dJ == 1: # jMin = jl, Mi = Ml
+        if alpha == 0: # pi trainsitions
+            s = 2.0 * ((Jl + 1)**2 - Ml**2)
+        elif alpha == -1: # sigma_b transitions
+            s = (Jl + Ml + 1) * (Jl + Ml + 2.0)
+        elif alpha == 1: # sigma_r transitions
+            s = (Jl - Ml + 1.0) * (Jl - Ml + 2.0)
+    elif dJ == -1: # jMin = ju, Mi = Mu
+        if alpha == 0: # pi trainsitions
+            s = 2.0 * ((Ju + 1)**2 - Mu**2)
+        elif alpha == -1: # sigma_b transitions
+            s = (Ju - Mu + 1) * (Ju - Mu + 2.0)
+        elif alpha == 1: # sigma_r transitions
+            s = (Ju + Mu + 1.0) * (Ju + Mu + 2.0)
+    else:
+        raise ValueError('Invalid dJ: %d' % dJ)
+
+    return float(s)
+
+def lande_factor(J: Fraction, L: int, S: Fraction) -> float:
+    if J == 0.0:
+        return 0.0
+    return float(1.5 + (S * (S + 1.0) - L * (L + 1)) / (2.0 * J * (J + 1.0)))
+
+def effective_lande(line: AtomicLine):
+    if line.gLandeEff is not None:
+        return line.gLandeEff
+
+    i = line.iLevel
+    j = line.jLevel
+    if any(x is None for x in [i.J, i.L, i.S, j.J, j.L, j.S]):
+        raise ValueError('Cannot compute gLandeEff as gLandeEff not set and some of J, L and S None for line %s'%repr(line))
+    gL = lande_factor(i.J, i.L, i.S) # type: ignore
+    gU = lande_factor(j.J, j.L, j.S) # type: ignore
+
+    return 0.5 * (gU + gL) + \
+           0.25 * (gU - gL) * (j.J * (j.J + 1.0) - i.J * (i.J + 1.0)) # type: ignore
+
+def compute_zeeman_components(line: AtomicLine) -> Optional[ZeemanComponents]:
+    # Just do basic anomalous Zeeman splitting
+    if line.gLandeEff is not None:
+        alpha = np.array([-1, 0, 1], dtype=np.int32)
+        strength = np.ones(3)
+        shift = alpha * line.gLandeEff
+        return ZeemanComponents(alpha, strength, shift)
+
+    # Do LS coupling
+    if line.iLevel.lsCoupling and line.jLevel.lsCoupling:
+        # Mypy... you're a pain sometimes... (even if you are technically correct)
+        Jl = cast(Fraction, line.iLevel.J)
+        Ll = cast(int, line.iLevel.L)
+        Sl = cast(Fraction, line.iLevel.S)
+        Ju = cast(Fraction, line.jLevel.J)
+        Lu = cast(int, line.jLevel.L)
+        Su = cast(Fraction, line.jLevel.S)
+
+        gLl = lande_factor(Jl, Ll, Sl)
+        gLu = lande_factor(Ju, Lu, Su)
+        alpha = []
+        strength = []
+        shift = []
+        norm = np.zeros(3)
+
+        for ml in fraction_range(-Jl, Jl+1):
+            for mu in fraction_range(-Ju, Ju+1):
+                if abs(ml - mu) <= 1.0:
+                    alpha.append(int(ml - mu))
+                    shift.append(gLl*ml - gLu*mu)
+                    strength.append(zeeman_strength(Ju, mu, Jl, ml))
+                    norm[alpha[-1]+1] += strength[-1]
+        alpha = np.array(alpha, dtype=np.int32)
+        strength = np.array(strength)
+        shift = np.array(shift)
+        strength /= norm[alpha + 1]
+
+        return ZeemanComponents(alpha, strength, shift)
+    return None


### PR DESCRIPTION
This large set of changes should make Lw substantially more robust to doing things I didn't originally consider, in addition to lots of code being better decoupled and tidier. Moving compute_phi to the VoigtLine to escape the assumption of Voigt (with fast escape hatch of just calling the provided callback if Voigt is all that is desired) is a good idea, but didn't fully fit this branch.